### PR TITLE
fix: authorization parameter encoding not as JSON

### DIFF
--- a/packages/client/lib/OpenID4VCIClient.ts
+++ b/packages/client/lib/OpenID4VCIClient.ts
@@ -144,6 +144,7 @@ export class OpenID4VCIClient {
       baseUrl: this._endpointMetadata.authorization_endpoint,
       uriTypeProperties: ['redirect_uri', 'scope', 'authorization_details'],
       version: this.version(),
+      encodeAsSingleJson: false,
     });
   }
 

--- a/packages/client/lib/functions/index.ts
+++ b/packages/client/lib/functions/index.ts
@@ -1,3 +1,3 @@
 export * from '@sphereon/oid4vci-common/dist/functions/Encoding';
-export * from '../../../common/lib/functions/HttpUtils';
+export * from '@sphereon/oid4vci-common/dist/functions/HttpUtils';
 export * from './ProofUtil';

--- a/packages/common/lib/functions/Encoding.ts
+++ b/packages/common/lib/functions/Encoding.ts
@@ -32,7 +32,7 @@ export function convertJsonToURI(
   }
 
   let components: string;
-  if (opts?.version && opts.version < OpenId4VCIVersion.VER_1_0_11) {
+  if ((opts?.version && opts.version < OpenId4VCIVersion.VER_1_0_11) || !(opts?.encodeAsSingleJson ?? true)) {
     for (const [key, value] of Object.entries(json)) {
       if (!value) {
         continue;

--- a/packages/common/lib/types/CredentialIssuance.types.ts
+++ b/packages/common/lib/types/CredentialIssuance.types.ts
@@ -59,6 +59,7 @@ export type EncodeJsonAsURIOpts = {
   baseUrl?: string;
   param?: string;
   version?: OpenId4VCIVersion;
+  encodeAsSingleJson?: boolean
 };
 
 export type DecodeURIAsJsonOpts = {


### PR DESCRIPTION
Small fix for encoding the Authorization Request.

The spec shows the example as:

```
GET /authorize?
  response_type=code
  &client_id=s6BhdRkqt3
  &code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
  &code_challenge_method=S256
  &authorization_details=%5B%7B%22type%22:%22openid_credential
  %22,%22format%22:%22jwt_vc_json%22,%22types%22:%5B%22Verifia
  bleCredential%22,%22UniversityDegreeCredential%22%5D%7D%5D
  &redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
Host: https://server.example.com
```

which encodes each key-value pair inside the JSON object as separate query parameters. Right now, it is encoded as the entire JSON body as a key and an empty string as value. 


The fix I used here is not the cleanest but it works as a simple override with the encoding algorithm used.