### PR TITLE
fix: rename jwt_vc_json_ld to jwt_vc_json-ld

### DIFF
--- a/packages/client/lib/CredentialRequestClient.ts
+++ b/packages/client/lib/CredentialRequestClient.ts
@@ -58,7 +58,7 @@ export class CredentialRequestClient {
       let format: string = uniformRequest.format;
       if (format === 'jwt_vc_json') {
         format = 'jwt_vc';
-      } else if (format === 'jwt_vc_json_ld') {
+      } else if (format === 'jwt_vc_json-ld') {
         format = 'ldp_vc';
       }
 
@@ -97,13 +97,13 @@ export class CredentialRequestClient {
       if (formatSelection === 'jwt_vc' || formatSelection === 'jwt') {
         format = 'jwt_vc_json';
       } else if (formatSelection === 'ldp_vc' || formatSelection === 'ldp') {
-        format = 'jwt_vc_json_ld';
+        format = 'jwt_vc_json-ld';
       }
     }
 
     if (!format) {
       throw Error(`Format of credential to be issued is missing`);
-    } else if (format !== 'jwt_vc_json_ld' && format !== 'jwt_vc_json' && format !== 'ldp_vc') {
+    } else if (format !== 'jwt_vc_json-ld' && format !== 'jwt_vc_json' && format !== 'ldp_vc') {
       throw Error(`Invalid format of credential to be issued: ${format}`);
     }
     const typesSelection =

--- a/packages/client/lib/__tests__/CredentialRequestClient.spec.ts
+++ b/packages/client/lib/__tests__/CredentialRequestClient.spec.ts
@@ -151,7 +151,7 @@ describe('Credential Request Client ', () => {
       .build();
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    await expect(credReqClient.acquireCredentialsUsingRequest({ format: 'jwt_vc_json_ld', types: ['random'], proof })).rejects.toThrow(
+    await expect(credReqClient.acquireCredentialsUsingRequest({ format: 'jwt_vc_json-ld', types: ['random'], proof })).rejects.toThrow(
       Error(URL_NOT_VALID)
     );
   });
@@ -194,7 +194,7 @@ describe('Credential Request Client with different issuers ', () => {
           jwt: getMockData('spruce')?.credential.request.proof.jwt as string,
         },
         credentialTypes: ['OpenBadgeCredential'],
-        format: 'jwt_vc_json_ld',
+        format: 'jwt_vc_json-ld',
         version: OpenId4VCIVersion.VER_1_0_08,
       });
     expect(credentialRequest).toEqual(getMockData('spruce')?.credential.request);

--- a/packages/client/lib/__tests__/IT.spec.ts
+++ b/packages/client/lib/__tests__/IT.spec.ts
@@ -103,7 +103,7 @@ describe('OID4VCI-Client should', () => {
 
     const credentialResponse = await client.acquireCredentials({
       credentialTypes: 'OpenBadgeCredential',
-      format: 'jwt_vc_json_ld',
+      format: 'jwt_vc_json-ld',
       proofCallbacks: {
         signCallback: proofOfPossessionCallbackFunction,
       },

--- a/packages/client/lib/__tests__/data/VciDataFixtures.ts
+++ b/packages/client/lib/__tests__/data/VciDataFixtures.ts
@@ -43,7 +43,7 @@ export interface IssuerMockData {
     deeplink: string;
     request: {
       types: [string];
-      format: 'jwt_vc' | 'ldp_vc' | 'jwt_vc_json_ld' | string;
+      format: 'jwt_vc' | 'ldp_vc' | 'jwt_vc_json-ld' | string;
       proof: {
         proof_type: 'jwt' | string;
         jwt: string;
@@ -111,7 +111,7 @@ const mockData: VciMockDataStructure = {
         'openid-initiate-issuance://?issuer=https%3A%2F%2Fngi%2Doidc4vci%2Dtest%2Espruceid%2Exyz&credential_type=OpenBadgeCredential&pre-authorized_code=eyJhbGciOiJFUzI1NiJ9.eyJjcmVkZW50aWFsX3R5cGUiOlsiT3BlbkJhZGdlQ3JlZGVudGlhbCJdLCJleHAiOiIyMDIzLTA0LTIwVDA5OjA0OjM2WiIsIm5vbmNlIjoibWFibmVpT0VSZVB3V3BuRFFweEt3UnRsVVRFRlhGUEwifQ.qOZRPN8sTv_knhp7WaWte2-aDULaPZX--2i9unF6QDQNUllqDhvxgIHMDCYHCV8O2_Gj-T2x1J84fDMajE3asg&user_pin_required=false',
       request: {
         types: ['OpenBadgeCredential'],
-        format: 'jwt_vc_json_ld',
+        format: 'jwt_vc_json-ld',
         proof: {
           proof_type: 'jwt',
           jwt: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksiLCJraWQiOiJkaWQ6andrOmV5SmhiR2NpT2lKRlV6STFOa3NpTENKMWMyVWlPaUp6YVdjaUxDSnJkSGtpT2lKRlF5SXNJbU55ZGlJNkluTmxZM0F5TlRack1TSXNJbmdpT2lKclpuVmpTa0V0VEhKck9VWjBPRmx5TFVkMlQzSmpia3N3YjNkc2RqUlhNblUwU3pJeFNHZHZTVlIzSWl3aWVTSTZJalozY0ZCUE1rOUNRVXBTU0ZFMVRXdEtXVlJaV0dsQlJFUXdOMU5OTlV0amVXcDNYMkUzVUUxWmVGa2lmUSMwIn0.eyJhdWQiOiJodHRwczovL25naS1vaWRjNHZjaS10ZXN0LnNwcnVjZWlkLnh5eiIsImlhdCI6MTY4MTkxMTA2MC45NDIsImV4cCI6MTY4MTkxMTcyMC45NDIsImlzcyI6InNwaGVyZW9uOnNzaS13YWxsZXQiLCJqdGkiOiJhNjA4MzMxZi02ZmE0LTQ0ZjAtYWNkZWY5NmFjMjdmNmQ3MCJ9.NwF3_41gwnlIdd_6Uk9CczeQHzIQt6UcvTT5Cxv72j9S1vNwiY9annA2kLsjsTiR5-WMBdUhJCO7wYCtZ15mxw',
@@ -366,7 +366,7 @@ const mockData: VciMockDataStructure = {
       response: {
         credential:
           'eyJraWQiOiJkaWQ6andrOmV5SnJkSGtpT2lKUFMxQWlMQ0oxYzJVaU9pSnphV2NpTENKamNuWWlPaUpGWkRJMU5URTVJaXdpYTJsa0lqb2lOMlEyWTJKbU1qUTRPV0l6TkRJM05tSXhOekl4T1RBMU5EbGtNak01TVRnaUxDSjRJam9pUm01RlZWVmhkV1J0T1RsT016QmlPREJxY3poV2REUkJiazk0ZGxKM1dIUm5VbU5MY1ROblFrbDFPQ0lzSW1Gc1p5STZJa1ZrUkZOQkluMCMwIiwidHlwIjoiSldUIiwiYWxnIjoiRWREU0EifQ.eyJpc3MiOiJkaWQ6andrOmV5SnJkSGtpT2lKUFMxQWlMQ0oxYzJVaU9pSnphV2NpTENKamNuWWlPaUpGWkRJMU5URTVJaXdpYTJsa0lqb2lOMlEyWTJKbU1qUTRPV0l6TkRJM05tSXhOekl4T1RBMU5EbGtNak01TVRnaUxDSjRJam9pUm01RlZWVmhkV1J0T1RsT016QmlPREJxY3poV2REUkJiazk0ZGxKM1dIUm5VbU5MY1ROblFrbDFPQ0lzSW1Gc1p5STZJa1ZrUkZOQkluMCIsInN1YiI6ImRpZDpqd2s6ZXlKaGJHY2lPaUpGVXpJMU5rc2lMQ0oxYzJVaU9pSnphV2NpTENKcmRIa2lPaUpGUXlJc0ltTnlkaUk2SW5ObFkzQXlOVFpyTVNJc0luZ2lPaUpyWm5WalNrRXRUSEpyT1VaME9GbHlMVWQyVDNKamJrc3diM2RzZGpSWE1uVTBTekl4U0dkdlNWUjNJaXdpZVNJNklqWjNjRkJQTWs5Q1FVcFNTRkUxVFd0S1dWUlpXR2xCUkVRd04xTk5OVXRqZVdwM1gyRTNVRTFaZUZraWZRIiwibmJmIjoxNjgxOTExOTk5LCJpYXQiOjE2ODE5MTE5OTksInZjIjp7InR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJPcGVuQmFkZ2VDcmVkZW50aWFsIl0sIkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9vYi92M3AwL2NvbnRleHQuanNvbiJdLCJpZCI6InVybjp1dWlkOmM0YTA4MDYzLTc4ZTUtNDdkNS04NGY5LTg2YTFmNjNiYzNkYSIsImlzc3VlciI6eyJpZCI6ImRpZDpqd2s6ZXlKcmRIa2lPaUpQUzFBaUxDSjFjMlVpT2lKemFXY2lMQ0pqY25ZaU9pSkZaREkxTlRFNUlpd2lhMmxrSWpvaU4yUTJZMkptTWpRNE9XSXpOREkzTm1JeE56SXhPVEExTkRsa01qTTVNVGdpTENKNElqb2lSbTVGVlZWaGRXUnRPVGxPTXpCaU9EQnFjemhXZERSQmJrOTRkbEozV0hSblVtTkxjVE5uUWtsMU9DSXNJbUZzWnlJNklrVmtSRk5CSW4wIiwiaW1hZ2UiOnsiaWQiOiJodHRwczovL3czYy1jY2cuZ2l0aHViLmlvL3ZjLWVkL3BsdWdmZXN0LTItMjAyMi9pbWFnZXMvSkZGLVZDLUVEVS1QTFVHRkVTVDItYmFkZ2UtaW1hZ2UucG5nIiwidHlwZSI6IkltYWdlIn0sIm5hbWUiOiJKb2JzIGZvciB0aGUgRnV0dXJlIChKRkYpIiwidHlwZSI6IlByb2ZpbGUiLCJ1cmwiOiJodHRwczovL3czYy1jY2cuZ2l0aHViLmlvL3ZjLWVkL3BsdWdmZXN0LTItMjAyMi9pbWFnZXMvSkZGLVZDLUVEVS1QTFVHRkVTVDItYmFkZ2UtaW1hZ2UucG5nIn0sImlzc3VhbmNlRGF0ZSI6IjIwMjMtMDQtMTlUMTM6NDY6MzlaIiwiaXNzdWVkIjoiMjAyMy0wNC0xOVQxMzo0NjozOVoiLCJ2YWxpZEZyb20iOiIyMDIzLTA0LTE5VDEzOjQ2OjM5WiIsImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoiZGlkOmp3azpleUpoYkdjaU9pSkZVekkxTmtzaUxDSjFjMlVpT2lKemFXY2lMQ0pyZEhraU9pSkZReUlzSW1OeWRpSTZJbk5sWTNBeU5UWnJNU0lzSW5naU9pSnJablZqU2tFdFRISnJPVVowT0ZseUxVZDJUM0pqYmtzd2IzZHNkalJYTW5VMFN6SXhTR2R2U1ZSM0lpd2llU0k2SWpaM2NGQlBNazlDUVVwU1NGRTFUV3RLV1ZSWldHbEJSRVF3TjFOTk5VdGplV3AzWDJFM1VFMVplRmtpZlEiLCJhY2hpZXZlbWVudCI6eyJjcml0ZXJpYSI6eyJuYXJyYXRpdmUiOiJUaGUgY29ob3J0IG9mIHRoZSBKRkYgUGx1Z2Zlc3QgMiBpbiBBdWd1c3QtTm92ZW1iZXIgb2YgMjAyMiBjb2xsYWJvcmF0ZWQgdG8gcHVzaCBpbnRlcm9wZXJhYmlsaXR5IG9mIFZDcyBpbiBlZHVjYXRpb24gZm9yd2FyZC4iLCJ0eXBlIjoiQ3JpdGVyaWEifSwiZGVzY3JpcHRpb24iOiJUaGlzIHdhbGxldCBjYW4gZGlzcGxheSB0aGlzIE9wZW4gQmFkZ2UgMy4wIiwiaWQiOiIwIiwiaW1hZ2UiOnsiaWQiOiJodHRwczovL3czYy1jY2cuZ2l0aHViLmlvL3ZjLWVkL3BsdWdmZXN0LTItMjAyMi9pbWFnZXMvSkZGLVZDLUVEVS1QTFVHRkVTVDItYmFkZ2UtaW1hZ2UucG5nIiwidHlwZSI6IkltYWdlIn0sIm5hbWUiOiJPdXIgV2FsbGV0IFBhc3NlZCBKRkYgUGx1Z2Zlc3QgIzIgMjAyMiIsInR5cGUiOiJBY2hpZXZlbWVudCJ9LCJ0eXBlIjoiQWNoaWV2ZW1lbnRTdWJqZWN0In0sIm5hbWUiOiJBY2hpZXZlbWVudCBDcmVkZW50aWFsIn0sImp0aSI6InVybjp1dWlkOmM0YTA4MDYzLTc4ZTUtNDdkNS04NGY5LTg2YTFmNjNiYzNkYSJ9.AM-lAUjCjcuQgy1QhQXctd3YrUoC2UdXvOwDHcHsi_UuHX0nt__QrYlfcwUutc9gSsz-U9SZ1e6iAGarTNVbDQ',
-        format: 'jwt_vc_json_ld',
+        format: 'jwt_vc_json-ld',
       },
     },
   },
@@ -574,7 +574,7 @@ const mockData: VciMockDataStructure = {
       url: 'https://launchpad.vii.electron.mattrlabs.io/oidc/v1/auth/credential',
       request: {
         types: ['OpenBadgeCredential'],
-        format: 'jwt_vc_json_ld',
+        format: 'jwt_vc_json-ld',
         proof: {
           proof_type: 'jwt',
           jwt: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3AxM3N6QUFMVFN0cDV1OGtMcnl5YW5vYWtrVWtFUGZXazdvOHY3dms0RW1KI3o2TWtwMTNzekFBTFRTdHA1dThrTHJ5eWFub2Fra1VrRVBmV2s3bzh2N3ZrNEVtSiJ9.eyJhdWQiOiJodHRwczovL2xhdW5jaHBhZC5tYXR0cmxhYnMuY29tIiwiaWF0IjoxNjgxOTE0NDgyLjUxOSwiZXhwIjoxNjgxOTE1MTQyLjUxOSwiaXNzIjoic3BoZXJlb246c3NpLXdhbGxldCIsImp0aSI6ImI5NDY1ZGE5LTY4OGYtNDdjNi04MjUwNDA0ZGNiOWI5Y2E5In0.uQ8ewOfIjy_1p_Gk6PjeEWccBJnjOca1pwbTWiCAFMQX9wlIsfeUdGtXUoHjH5_PQtpwytodx7WU456_CT9iBQ',
@@ -688,7 +688,7 @@ const mockData: VciMockDataStructure = {
       url: 'https://oidc4vc.diwala.io/credential',
       request: {
         types: ['OpenBadgeCredential'],
-        format: 'jwt_vc_json_ld',
+        format: 'jwt_vc_json-ld',
         proof: {
           proof_type: 'jwt',
           jwt: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3AxM3N6QUFMVFN0cDV1OGtMcnl5YW5vYWtrVWtFUGZXazdvOHY3dms0RW1KI3o2TWtwMTNzekFBTFRTdHA1dThrTHJ5eWFub2Fra1VrRVBmV2s3bzh2N3ZrNEVtSiJ9.eyJhdWQiOiJodHRwczovL29pZGM0dmMuZGl3YWxhLmlvIiwiaWF0IjoxNjgxOTE1MDk1LjIwMiwiZXhwIjoxNjgxOTE1NzU1LjIwMiwiaXNzIjoic3BoZXJlb246c3NpLXdhbGxldCIsImp0aSI6IjYxN2MwM2EzLTM3MTUtNGJlMy1hYjkxNzM4MTlmYzYxNTYzIn0.KA-cHjecaYp9FSaWHkz5cqtNyhBIVT_0I7cJnpHn03T4UWFvdhjhn8Hpe-BU247enFyWOWJ6v3NQZyZgle7xBA',

--- a/packages/common/lib/types/Generic.types.ts
+++ b/packages/common/lib/types/Generic.types.ts
@@ -15,7 +15,7 @@ export interface CredentialLogo {
   [key: string]: unknown;
 }
 
-export type OID4VCICredentialFormat = 'jwt_vc_json' | 'jwt_vc_json_ld' | 'ldp_vc' /*| 'mso_mdoc'*/; // we do not support mdocs at this point
+export type OID4VCICredentialFormat = 'jwt_vc_json' | 'jwt_vc_json-ld' | 'ldp_vc' /*| 'mso_mdoc'*/; // we do not support mdocs at this point
 
 export interface NameAndLocale {
   name?: string; // REQUIRED. String value of a display name for the Credential.
@@ -169,7 +169,7 @@ export interface CredentialRequestJwtVcJson extends CommonCredentialRequest {
 }
 
 export interface CredentialRequestJwtVcJsonLdAndLdpVc extends CommonCredentialRequest {
-  format: 'jwt_vc_json_ld' | 'ldp_vc';
+  format: 'jwt_vc_json-ld' | 'ldp_vc';
   credential_definition: IssuerCredentialDefinition;
 }
 
@@ -182,7 +182,7 @@ export interface CommonCredentialResponse {
 }
 
 export interface CredentialResponseJwtVcJsonLdAndLdpVc extends CommonCredentialResponse {
-  format: 'jwt_vc_json_ld' | 'ldp_vc';
+  format: 'jwt_vc_json-ld' | 'ldp_vc';
   credential: IVerifiableCredential;
 }
 

--- a/packages/issuer/lib/VcIssuer.ts
+++ b/packages/issuer/lib/VcIssuer.ts
@@ -255,7 +255,7 @@ export class VcIssuer {
     clientId?: string
     jwtVerifyCallback?: JWTVerifyCallback
   }) {
-    if (credentialRequest.format !== 'jwt_vc_json' && credentialRequest.format !== 'jwt_vc_json_ld') {
+    if (credentialRequest.format !== 'jwt_vc_json' && credentialRequest.format !== 'jwt_vc_json-ld') {
       throw Error(`Format ${credentialRequest.format} not supported yet`)
     } else if (typeof this._verifyCallback !== 'function' && typeof jwtVerifyCallback !== 'function') {
       throw new Error(JWT_VERIFY_CONFIG_ERROR)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 importers:
 


### PR DESCRIPTION
According to https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-e.1 the format identifier for a VC signed as a JWT, using JSON-ld is `jwt_vc_json-ld`.

(a better fix might be to keep the format identifiers in an enum and reuse them form there.)