### PR TITLE
feat: inline credential offers and credential supported mapping improvements

### DIFF
--- a/packages/callback-example/lib/__tests__/issuerCallback.spec.ts
+++ b/packages/callback-example/lib/__tests__/issuerCallback.spec.ts
@@ -192,8 +192,6 @@ describe('issuerCallback', () => {
   it('Should pass requesting a verifiable credential using the client', async () => {
     const credReqClient = (await CredentialRequestClientBuilder.fromURI({ uri: INITIATION_TEST_URI }))
       .withCredentialEndpoint('https://oidc4vci.demo.spruceid.com/credential')
-      .withFormat('jwt_vc_json')
-      .withCredentialType('credentialType')
       .withToken('token')
 
     const jwt: Jwt = {
@@ -221,19 +219,26 @@ describe('issuerCallback', () => {
       .build()
 
     const credentialRequestClient = new CredentialRequestClient(credReqClient)
+
+    // FIXME: The initiation is v8, but the test expects a v9 credential request.
+    // it will now fail because of a check if we don't change the version.
+    // the QR should be changed, or the output check should be changed
+    credentialRequestClient.credentialRequestOpts.version = OpenId4VCIVersion.VER_1_0_09
+
     const credentialRequest = await credentialRequestClient.createCredentialRequest({
-      credentialTypes: ['VerifiableCredential'],
-      format: 'jwt_vc_json',
+      requestInput: {
+        types: ['VerifiableCredential'],
+        format: 'jwt_vc_json',
+      },
       proofInput: proof,
-      version: OpenId4VCIVersion.VER_1_0_11,
     })
     expect(credentialRequest).toEqual({
       format: 'jwt_vc_json',
+      types: ['VerifiableCredential'],
       proof: {
         jwt: expect.stringContaining('eyJhbGciOiJFUzI1NiIsImtpZCI6ImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFj'),
         proof_type: 'jwt',
       },
-      types: ['VerifiableCredential'],
     })
 
     const credentialResponse = await vcIssuer.issueCredential({

--- a/packages/client/lib/CredentialRequestClient.ts
+++ b/packages/client/lib/CredentialRequestClient.ts
@@ -1,6 +1,10 @@
 import {
+  CredentialOfferFormat,
   CredentialRequestV1_0_08,
   CredentialResponse,
+  CredentialSupported,
+  CredentialSupportedJwtVcJsonLdAndLdpVc,
+  getFormatForVersion,
   OID4VCICredentialFormat,
   OpenId4VCIVersion,
   OpenIDResponse,
@@ -19,11 +23,21 @@ const debug = Debug('sphereon:oid4vci:credential');
 
 export interface CredentialRequestOpts {
   credentialEndpoint: string;
-  credentialTypes: string[];
-  format?: CredentialFormat | OID4VCICredentialFormat;
   proof: ProofOfPossession;
   token: string;
   version: OpenId4VCIVersion;
+}
+
+export interface RequestFromCredentialSupported {
+  credentialSupported: { id: string; format: OID4VCICredentialFormat | CredentialFormat | string } | CredentialSupported;
+}
+
+export interface RequestFromInlineCredentialOffer {
+  inlineCredentialOffer: CredentialOfferFormat;
+}
+
+export interface RequestFromRequestInput {
+  requestInput: UniformCredentialRequest & { proof?: never };
 }
 
 export class CredentialRequestClient {
@@ -41,97 +55,159 @@ export class CredentialRequestClient {
     this._credentialRequestOpts = { ...builder };
   }
 
-  public async acquireCredentialsUsingProof(opts: {
-    proofInput: ProofOfPossessionBuilder | ProofOfPossession;
-    credentialTypes?: string | string[];
-    format?: CredentialFormat | OID4VCICredentialFormat;
-  }): Promise<OpenIDResponse<CredentialResponse>> {
-    const { credentialTypes, proofInput, format } = opts;
+  public async acquireCredentialsUsingProof(
+    opts: { proofInput: ProofOfPossessionBuilder | ProofOfPossession } & (
+      | RequestFromCredentialSupported
+      | RequestFromInlineCredentialOffer
+      | RequestFromRequestInput
+    )
+  ): Promise<OpenIDResponse<CredentialResponse>> {
+    // Get request based on credential offer or credentialSupported.
+    const request =
+      // inline credential offer
+      'inlineCredentialOffer' in opts
+        ? await this.createCredentialRequestFromInlineOffer(opts)
+        : // credential supported
+        'credentialSupported' in opts
+        ? await this.createCredentialRequestFromCredentialSupported(opts)
+        : // direct request input
+          await this.createCredentialRequest(opts);
 
-    const request = await this.createCredentialRequest({ proofInput, credentialTypes, format, version: this.version() });
     return await this.acquireCredentialsUsingRequest(request);
   }
 
-  public async acquireCredentialsUsingRequest(uniformRequest: UniformCredentialRequest): Promise<OpenIDResponse<CredentialResponse>> {
-    let request: CredentialRequestV1_0_08 | UniformCredentialRequest = uniformRequest;
-    if (!this.isV11OrHigher()) {
-      let format: string = uniformRequest.format;
-      if (format === 'jwt_vc_json') {
-        format = 'jwt_vc';
-      } else if (format === 'jwt_vc_json-ld') {
-        format = 'ldp_vc';
-      }
-
-      request = {
-        format,
-        proof: uniformRequest.proof,
-        type:
-          'types' in uniformRequest
-            ? uniformRequest.types.filter((t) => t !== 'VerifiableCredential')[0]
-            : uniformRequest.credential_definition.types[0],
-      } as CredentialRequestV1_0_08;
+  public async acquireCredentialsUsingRequest(
+    request: UniformCredentialRequest | CredentialRequestV1_0_08
+  ): Promise<OpenIDResponse<CredentialResponse>> {
+    // If the version is below draft 11, the request also needs to be a CredentialRequestV1_0_08
+    if (this.version() === OpenId4VCIVersion.VER_1_0_08 && !('type' in request)) {
+      throw new Error(
+        `Missing required 'type' property in credential request. Make sure to provide a 'CredentialRequestV1_0_08' object when version is draft 8`
+      );
     }
+
     const credentialEndpoint: string = this.credentialRequestOpts.credentialEndpoint;
     if (!isValidURL(credentialEndpoint)) {
       debug(`Invalid credential endpoint: ${credentialEndpoint}`);
       throw new Error(URL_NOT_VALID);
     }
     debug(`Acquiring credential(s) from: ${credentialEndpoint}`);
-    const requestToken: string = this.credentialRequestOpts.token;
+    const requestToken = this.credentialRequestOpts.token;
     const response: OpenIDResponse<CredentialResponse> = await post(credentialEndpoint, JSON.stringify(request), { bearerToken: requestToken });
     debug(`Credential endpoint ${credentialEndpoint} response:\r\n${response}`);
     return response;
   }
 
-  public async createCredentialRequest(opts: {
-    proofInput: ProofOfPossessionBuilder | ProofOfPossession;
-    credentialTypes?: string | string[];
-    format?: CredentialFormat | OID4VCICredentialFormat;
-    version: OpenId4VCIVersion;
-  }): Promise<UniformCredentialRequest> {
-    const { proofInput } = opts;
-    const formatSelection = opts.format ?? this.credentialRequestOpts.format;
+  public async createCredentialRequestFromInlineOffer(
+    opts: { proofInput: ProofOfPossessionBuilder | ProofOfPossession } & RequestFromInlineCredentialOffer
+  ): Promise<UniformCredentialRequest> {
+    const { inlineCredentialOffer } = opts;
 
-    let format: OID4VCICredentialFormat = formatSelection as OID4VCICredentialFormat;
-    if (opts.version < OpenId4VCIVersion.VER_1_0_11) {
-      if (formatSelection === 'jwt_vc' || formatSelection === 'jwt') {
-        format = 'jwt_vc_json';
-      } else if (formatSelection === 'ldp_vc' || formatSelection === 'ldp') {
-        format = 'jwt_vc_json-ld';
+    if (!this.isV9OrHigher()) {
+      throw new Error('Inline credential offers are only supported for draft 9 and higher');
+    }
+
+    // Transform the inline offer into a credential request
+    if (inlineCredentialOffer.format === 'jwt_vc_json') {
+      return {
+        format: inlineCredentialOffer.format,
+        types: inlineCredentialOffer.types,
+        proof: await this.buildProof(opts.proofInput),
+      };
+    } else if (inlineCredentialOffer.format === 'jwt_vc_json-ld' || inlineCredentialOffer.format === 'ldp_vc') {
+      return {
+        format: inlineCredentialOffer.format,
+        credential_definition: inlineCredentialOffer.credential_definition,
+        proof: await this.buildProof(opts.proofInput),
+      };
+    } else {
+      throw new Error(`Unsupported credential offer format: ${inlineCredentialOffer.format}`);
+    }
+  }
+
+  public async createCredentialRequestFromCredentialSupported(
+    opts: { proofInput: ProofOfPossessionBuilder | ProofOfPossession } & RequestFromCredentialSupported
+  ): Promise<UniformCredentialRequest | CredentialRequestV1_0_08> {
+    const { credentialSupported } = opts;
+
+    const format = getFormatForVersion(credentialSupported.format, this.version());
+
+    if (!this.isV9OrHigher()) {
+      // Below v9, the `id` is required as it must be passed in the request
+      if (typeof credentialSupported.id !== 'string') {
+        throw new Error(`Missing required credential supported id for versions below draft 9`);
       }
+
+      // Remove the suffix from the id that is added by us when multiple formats for a supported credential exist
+      // this is behavior to make the API of draft 11 align with the API of lower versions
+      if (credentialSupported.id.endsWith(`-${credentialSupported.format}`)) {
+        credentialSupported.id = credentialSupported.id.replace(`-${credentialSupported.format}`, '');
+      }
+
+      return {
+        format,
+        type: credentialSupported.id,
+        proof: await this.buildProof(opts.proofInput),
+      } satisfies CredentialRequestV1_0_08;
     }
 
-    if (!format) {
-      throw Error(`Format of credential to be issued is missing`);
-    } else if (format !== 'jwt_vc_json-ld' && format !== 'jwt_vc_json' && format !== 'ldp_vc') {
-      throw Error(`Invalid format of credential to be issued: ${format}`);
-    }
-    const typesSelection =
-      opts?.credentialTypes && (typeof opts.credentialTypes === 'string' || opts.credentialTypes.length > 0)
-        ? opts.credentialTypes
-        : this.credentialRequestOpts.credentialTypes;
-    const types = Array.isArray(typesSelection) ? typesSelection : [typesSelection];
-    if (types.length === 0) {
-      throw Error(`Credential type(s) need to be provided`);
-    } else if (!this.isV11OrHigher() && types.length !== 1) {
-      throw Error('Only a single credential type is supported for V8/V9');
+    // We require the credential supported
+    if (!('types' in credentialSupported)) {
+      throw new Error(`Missing required 'types' property in credential supported. Make sure to provide a 'CredentialSupported' object`);
     }
 
-    const proof =
-      'proof_type' in proofInput
-        ? await ProofOfPossessionBuilder.fromProof(proofInput as ProofOfPossession, opts.version).build()
-        : await proofInput.build();
+    // Transform the credential supported into a credential request
+    if (format === 'jwt_vc_json') {
+      return {
+        format: 'jwt_vc_json',
+        types: credentialSupported.types,
+        proof: await this.buildProof(opts.proofInput),
+      } satisfies UniformCredentialRequest;
+    } else if (format === 'jwt_vc_json-ld' || format === 'ldp_vc') {
+      const supported = credentialSupported as CredentialSupportedJwtVcJsonLdAndLdpVc;
+      return {
+        format,
+        credential_definition: {
+          '@context': supported['@context'],
+          types: credentialSupported.types,
+        },
+      } satisfies UniformCredentialRequest;
+    } else {
+      throw new Error(`Unsupported credential supported format: ${credentialSupported.format}`);
+    }
+  }
+
+  public async createCredentialRequest(
+    opts: {
+      proofInput: ProofOfPossessionBuilder | ProofOfPossession;
+    } & RequestFromRequestInput
+  ): Promise<UniformCredentialRequest> {
+    const { requestInput } = opts;
+
+    if (!this.isV9OrHigher()) {
+      throw new Error(
+        'Creating credential request directly is only supported for versions using draft 9 and higher. Use `createCredentialRequestFromCredentialSupported` for lower versions'
+      );
+    }
+
     return {
-      types,
-      format,
-      proof,
-    } as UniformCredentialRequest;
+      ...requestInput,
+      proof: await this.buildProof(opts.proofInput),
+    };
+  }
+
+  private async buildProof(proofInput: ProofOfPossessionBuilder | ProofOfPossession): Promise<ProofOfPossession> {
+    const proof =
+      'proof_type' in proofInput ? await ProofOfPossessionBuilder.fromProof(proofInput, this.version()).build() : await proofInput.build();
+
+    return proof;
   }
 
   private version(): OpenId4VCIVersion {
     return this.credentialRequestOpts?.version ?? OpenId4VCIVersion.VER_1_0_11;
   }
-  private isV11OrHigher(): boolean {
-    return this.version() >= OpenId4VCIVersion.VER_1_0_11;
+
+  private isV9OrHigher(): boolean {
+    return this.version() >= OpenId4VCIVersion.VER_1_0_09;
   }
 }

--- a/packages/client/lib/CredentialRequestClientBuilder.ts
+++ b/packages/client/lib/CredentialRequestClientBuilder.ts
@@ -1,24 +1,19 @@
 import {
   AccessTokenResponse,
   CredentialIssuerMetadata,
-  CredentialOfferPayloadV1_0_08,
   CredentialOfferRequestWithBaseUrl,
   determineSpecVersionFromOffer,
   EndpointMetadata,
   getIssuerFromCredentialOfferPayload,
-  OID4VCICredentialFormat,
   OpenId4VCIVersion,
   UniformCredentialOfferRequest,
 } from '@sphereon/oid4vci-common';
-import { CredentialFormat } from '@sphereon/ssi-types';
 
 import { CredentialOfferClient } from './CredentialOfferClient';
 import { CredentialRequestClient } from './CredentialRequestClient';
 
 export class CredentialRequestClientBuilder {
   credentialEndpoint?: string;
-  credentialTypes: string[] = [];
-  format?: CredentialFormat | OID4VCICredentialFormat;
   token?: string;
   version?: OpenId4VCIVersion;
 
@@ -40,14 +35,6 @@ export class CredentialRequestClientBuilder {
     const issuer = getIssuerFromCredentialOfferPayload(request.credential_offer) ?? (metadata?.issuer as string);
     builder.withVersion(version);
     builder.withCredentialEndpoint(metadata?.credential_endpoint ?? (issuer.endsWith('/') ? `${issuer}credential` : `${issuer}/credential`));
-
-    if (version <= OpenId4VCIVersion.VER_1_0_08) {
-      //todo: This basically sets all types available during initiation. Probably the user only wants a subset. So do we want to do this?
-      builder.withCredentialType((request.original_credential_offer as CredentialOfferPayloadV1_0_08).credential_type);
-    } else {
-      // todo: look whether this is correct
-      builder.withCredentialType(request.credential_offer.credentials.flatMap((c) => (typeof c === 'string' ? c : c.types)));
-    }
 
     return builder;
   }
@@ -73,16 +60,6 @@ export class CredentialRequestClientBuilder {
 
   public withCredentialEndpoint(credentialEndpoint: string): CredentialRequestClientBuilder {
     this.credentialEndpoint = credentialEndpoint;
-    return this;
-  }
-
-  public withCredentialType(credentialTypes: string | string[]): CredentialRequestClientBuilder {
-    this.credentialTypes = Array.isArray(credentialTypes) ? credentialTypes : [credentialTypes];
-    return this;
-  }
-
-  public withFormat(format: CredentialFormat | OID4VCICredentialFormat): CredentialRequestClientBuilder {
-    this.format = format;
     return this;
   }
 

--- a/packages/client/lib/OpenID4VCIClient.ts
+++ b/packages/client/lib/OpenID4VCIClient.ts
@@ -10,6 +10,8 @@ import {
   CredentialResponse,
   CredentialSupported,
   EndpointMetadata,
+  OfferedCredentialsWithMetadata,
+  OfferedCredentialType,
   OpenId4VCIVersion,
   OpenIDResponse,
   ProofOfPossessionCallbacks,
@@ -405,8 +407,8 @@ export class OpenID4VCIClient {
    * from this method could contain multiple entries for a single credential id, but with different formats. This is detectable as the
    * id will be the `<credentialId>-<format>`.
    */
-  getOfferedCredentialsWithMetadata(): Array<CredentialSupported | CredentialOfferFormat> {
-    const offeredCredentials: Array<CredentialSupported | CredentialOfferFormat> = [];
+  getOfferedCredentialsWithMetadata(): Array<OfferedCredentialsWithMetadata> {
+    const offeredCredentials: Array<OfferedCredentialsWithMetadata> = [];
 
     for (const offeredCredential of this.getOfferedCredentials()) {
       // If the offeredCredential is a string, it references a supported credential in the issuer metadata
@@ -418,7 +420,11 @@ export class OpenID4VCIClient {
           throw new Error(`Offered credential '${offeredCredential}' is not present in the credentials_supported of the issuer metadata`);
         }
 
-        offeredCredentials.push(...credentialsSupported);
+        offeredCredentials.push(
+          ...credentialsSupported.map((credentialSupported) => {
+            return { credentialSupported, type: OfferedCredentialType.CredentialSupported } as const;
+          })
+        );
       }
       // Otherwise it's an inline credential offer that does not reference a supported credential in the issuer metadata
       else {
@@ -438,7 +444,7 @@ export class OpenID4VCIClient {
         //      types: offeredCredential.credential_definition.types,
         //    } satisfies CredentialSupported;
         //  }
-        offeredCredentials.push(offeredCredential);
+        offeredCredentials.push({ inlineCredentialOffer: offeredCredential, type: OfferedCredentialType.InlineCredentialOffer } as const);
       }
     }
 

--- a/packages/client/lib/__tests__/IT.spec.ts
+++ b/packages/client/lib/__tests__/IT.spec.ts
@@ -48,9 +48,9 @@ describe('OID4VCI-Client should', () => {
   const mockedVC =
     'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sImlkIjoiaHR0cDovL2V4YW1wbGUuZWR1L2NyZWRlbnRpYWxzLzM3MzIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiVW5pdmVyc2l0eURlZ3JlZUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiaHR0cHM6Ly9leGFtcGxlLmVkdS9pc3N1ZXJzLzU2NTA0OSIsImlzc3VhbmNlRGF0ZSI6IjIwMTAtMDEtMDFUMDA6MDA6MDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMifX19LCJpc3MiOiJodHRwczovL2V4YW1wbGUuZWR1L2lzc3VlcnMvNTY1MDQ5IiwibmJmIjoxMjYyMzA0MDAwLCJqdGkiOiJodHRwOi8vZXhhbXBsZS5lZHUvY3JlZGVudGlhbHMvMzczMiIsInN1YiI6ImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJ9.z5vgMTK1nfizNCg5N-niCOL3WUIAL7nXy-nGhDZYO_-PNGeE-0djCpWAMH8fD8eWSID5PfkPBYkx_dfLJnQ7NA';
   const INITIATE_QR =
-    'openid-initiate-issuance://?issuer=https%3A%2F%2Fissuer.research.identiproof.io&credential_type=OpenBadgeCredentialUrl&pre-authorized_code=4jLs9xZHEfqcoow0kHE7d1a8hUk6Sy-5bVSV2MqBUGUgiFFQi-ImL62T-FmLIo8hKA1UdMPH0lM1xAgcFkJfxIw9L-lI3mVs0hRT8YVwsEM1ma6N3wzuCdwtMU4bcwKp&user_pin_required=true';
+    'openid-initiate-issuance://?issuer=https%3A%2F%2Fissuer.research.identiproof.io&credential_type=OpenBadgeCredential&pre-authorized_code=4jLs9xZHEfqcoow0kHE7d1a8hUk6Sy-5bVSV2MqBUGUgiFFQi-ImL62T-FmLIo8hKA1UdMPH0lM1xAgcFkJfxIw9L-lI3mVs0hRT8YVwsEM1ma6N3wzuCdwtMU4bcwKp&user_pin_required=true';
   const OFFER_QR =
-    'openid-credential-offer://credential_offer=%7B%22credential_issuer%22:%22https://credential-issuer.example.com%22,%22credentials%22:%5B%7B%22format%22:%22jwt_vc_json%22,%22types%22:%5B%22VerifiableCredential%22,%22UniversityDegreeCredential%22%5D%7D%5D,%22issuer_state%22:%22eyJhbGciOiJSU0Et...FYUaBy%22%7D';
+    'openid-credential-offer://?credential_offer=%7B%22credential_issuer%22:%22https://credential-issuer.example.com%22,%22credentials%22:%5B%7B%22format%22:%22jwt_vc_json%22,%22types%22:%5B%22VerifiableCredential%22,%22UniversityDegreeCredential%22%5D%7D%5D,%22issuer_state%22:%22eyJhbGciOiJSU0Et...FYUaBy%22%7D';
 
   function succeedWithAFullFlowWithClientSetup() {
     nock(IDENTIPROOF_ISSUER_URL).get('/.well-known/openid-credential-issuer').reply(200, JSON.stringify(IDENTIPROOF_OID4VCI_METADATA));
@@ -102,8 +102,10 @@ describe('OID4VCI-Client should', () => {
     expect(accessToken).toEqual(mockedAccessTokenResponse);
 
     const credentialResponse = await client.acquireCredentials({
-      credentialTypes: 'OpenBadgeCredential',
-      format: 'jwt_vc_json-ld',
+      credentialSupported: {
+        id: 'OpenBadgeCredential',
+        format: 'jwt_vc_json-ld',
+      },
       proofCallbacks: {
         signCallback: proofOfPossessionCallbackFunction,
       },
@@ -119,7 +121,7 @@ describe('OID4VCI-Client should', () => {
 
       expect(credentialOffer.baseUrl).toEqual('openid-initiate-issuance://');
       expect(credentialOffer.original_credential_offer).toEqual({
-        credential_type: ['OpenBadgeCredentialUrl'],
+        credential_type: ['OpenBadgeCredential'],
         issuer: ISSUER_URL,
         'pre-authorized_code':
           '4jLs9xZHEfqcoow0kHE7d1a8hUk6Sy-5bVSV2MqBUGUgiFFQi-ImL62T-FmLIo8hKA1UdMPH0lM1xAgcFkJfxIw9L-lI3mVs0hRT8YVwsEM1ma6N3wzuCdwtMU4bcwKp',
@@ -142,7 +144,6 @@ describe('OID4VCI-Client should', () => {
           credential: mockedVC,
         });
       const credReqClient = CredentialRequestClientBuilder.fromCredentialOffer({ credentialOffer: credentialOffer })
-        .withFormat('jwt_vc')
 
         .withTokenFromResponse(accessTokenResponse.successBody!)
         .build();
@@ -165,7 +166,10 @@ describe('OID4VCI-Client should', () => {
         })
         .withKid('did:example:ebfeb1f712ebc6f1c276e12ec21/keys/1')
         .build();
-      const credResponse = await credReqClient.acquireCredentialsUsingProof({ proofInput: proof });
+      const credResponse = await credReqClient.acquireCredentialsUsingProof({
+        proofInput: proof,
+        credentialSupported: { id: 'test', format: 'jwt_vc' },
+      });
       expect(credResponse.successBody?.credential).toEqual(mockedVC);
     },
     UNIT_TEST_TIMEOUT

--- a/packages/common/lib/functions/Formats.ts
+++ b/packages/common/lib/functions/Formats.ts
@@ -1,0 +1,38 @@
+import { CredentialFormat } from '@sphereon/ssi-types';
+
+import { OID4VCICredentialFormat, OpenId4VCIVersion } from '../types';
+
+const isUniformFormat = (format: string): format is OID4VCICredentialFormat => {
+  return ['jwt_vc_json', 'jwt_vc_json-ld', 'ldp_vc'].includes(format);
+};
+
+export function getUniformFormat(format: string | OID4VCICredentialFormat | CredentialFormat): OID4VCICredentialFormat {
+  // Already valid format
+  if (isUniformFormat(format)) {
+    return format;
+  }
+
+  // Older formats
+  if (format === 'jwt_vc' || format === 'jwt') {
+    return 'jwt_vc_json';
+  }
+  if (format === 'ldp_vc' || format === 'ldp') {
+    return 'ldp_vc';
+  }
+
+  throw new Error(`Invalid format: ${format}`);
+}
+
+export function getFormatForVersion(format: string, version: OpenId4VCIVersion) {
+  const uniformFormat = isUniformFormat(format) ? format : getUniformFormat(format);
+
+  if (version < OpenId4VCIVersion.VER_1_0_11) {
+    if (uniformFormat === 'jwt_vc_json') {
+      return 'jwt_vc' as const;
+    } else if (uniformFormat === 'ldp_vc' || uniformFormat === 'jwt_vc_json-ld') {
+      return 'ldp_vc' as const;
+    }
+  }
+
+  return uniformFormat;
+}

--- a/packages/common/lib/functions/IssuerMetadataUtils.ts
+++ b/packages/common/lib/functions/IssuerMetadataUtils.ts
@@ -1,6 +1,5 @@
 import {
   CredentialIssuerMetadata,
-  CredentialOfferFormat,
   CredentialSupported,
   CredentialSupportedTypeV1_0_08,
   CredentialSupportedV1_0_08,
@@ -12,15 +11,14 @@ import {
 export function getSupportedCredentials(opts?: {
   issuerMetadata?: CredentialIssuerMetadata | IssuerMetadataV1_0_08;
   version: OpenId4VCIVersion;
-  credentialTypes?: (CredentialOfferFormat | string)[];
-  supportedType?: CredentialOfferFormat | string;
+  credentialSupportedIds?: string[];
 }): CredentialSupported[] {
   const { issuerMetadata } = opts ?? {};
   let credentialsSupported: CredentialSupported[];
   if (!issuerMetadata) {
     return [];
   }
-  const { version, credentialTypes, supportedType } = opts ?? { version: OpenId4VCIVersion.VER_1_0_11 };
+  const { version, credentialSupportedIds } = opts ?? { version: OpenId4VCIVersion.VER_1_0_11 };
 
   const usesTransformedCredentialsSupported = version === OpenId4VCIVersion.VER_1_0_08 || !Array.isArray(issuerMetadata.credentials_supported);
   if (usesTransformedCredentialsSupported) {
@@ -31,25 +29,21 @@ export function getSupportedCredentials(opts?: {
 
   if (credentialsSupported === undefined || credentialsSupported.length === 0) {
     return [];
-  } else if (!credentialTypes || credentialTypes.length === 0) {
+  } else if (!credentialSupportedIds || credentialSupportedIds.length === 0) {
     return credentialsSupported;
   }
-  /**
-   * the following (not array part is a legacy code from version 1_0-08 which JFF plugfest 2 implementors used)
-   */
-  const initiationTypes = supportedType ? [supportedType] : credentialTypes;
 
   const credentialSupportedOverlap: CredentialSupported[] = [];
-  for (const offerType of initiationTypes) {
-    if (typeof offerType === 'string') {
+  for (const credentialSupportedId of credentialSupportedIds) {
+    if (typeof credentialSupportedId === 'string') {
       const supported = credentialsSupported.find((sup) => {
         // Match id to offerType
-        if (sup.id === offerType) return true;
+        if (sup.id === credentialSupportedId) return true;
 
         // If the credential was transformed and the v8 variant supported multiple formats for the id, we
         // check if there is an id with the format
         // see credentialsSupportedV8ToV11
-        if (usesTransformedCredentialsSupported && sup.id === `${offerType}-${sup.format}`) return true;
+        if (usesTransformedCredentialsSupported && sup.id === `${credentialSupportedId}-${sup.format}`) return true;
 
         return false;
       });

--- a/packages/common/lib/functions/index.ts
+++ b/packages/common/lib/functions/index.ts
@@ -1,3 +1,4 @@
 export * from './CredentialOfferUtil';
 export * from './Encoding';
 export * from './TypeConversionUtils';
+export * from './Formats';

--- a/packages/common/lib/types/Generic.types.ts
+++ b/packages/common/lib/types/Generic.types.ts
@@ -109,6 +109,20 @@ export interface CredentialOfferFormatJwtVcJsonLdAndLdpVc extends CommonCredenti
 
 export type CredentialOfferFormat = CommonCredentialOfferFormat & (CredentialOfferFormatJwtVcJson | CredentialOfferFormatJwtVcJsonLdAndLdpVc);
 
+/**
+ * The type of a credential offer entry. For each item in `credentials` array, the type MUST be one of the following:
+ *  - CredentialSupported, when the value is a string and points to a credential from the `credentials_supported` array.
+ *  - InlineCredentialOffer, when the value is a JSON object that represents an inline credential offer.
+ */
+export enum OfferedCredentialType {
+  CredentialSupported = 'CredentialSupported',
+  InlineCredentialOffer = 'InlineCredentialOffer',
+}
+
+export type OfferedCredentialsWithMetadata =
+  | { credentialSupported: CredentialSupported; type: OfferedCredentialType.CredentialSupported }
+  | { inlineCredentialOffer: CredentialOfferFormat; type: OfferedCredentialType.InlineCredentialOffer };
+
 export interface IssuerCredentialDefinition {
   '@context': ICredentialContextType[];
   types: string[];

--- a/packages/common/lib/types/Generic.types.ts
+++ b/packages/common/lib/types/Generic.types.ts
@@ -90,15 +90,29 @@ export interface CredentialSupportedJwtVcJson extends CommonCredentialSupported 
 
 export type CredentialSupported = CommonCredentialSupported & (CredentialSupportedJwtVcJson | CredentialSupportedJwtVcJsonLdAndLdpVc);
 
-export interface CredentialOfferFormat {
+export interface CommonCredentialOfferFormat {
   format: OID4VCICredentialFormat | string;
-  types: string[];
 }
+
+export interface CredentialOfferFormatJwtVcJson extends CommonCredentialOfferFormat {
+  format: 'jwt_vc_json';
+  types: string[]; // REQUIRED. JSON array as defined in Appendix E.1.1.2. This claim contains the type values the Wallet shall request in the subsequent Credential Request.
+}
+
+export interface CredentialOfferFormatJwtVcJsonLdAndLdpVc extends CommonCredentialOfferFormat {
+  format: 'jwt_vc_json-ld' | 'ldp_vc';
+  credential_definition: {
+    '@context': ICredentialContextType[]; // REQUIRED.
+    types: string[]; // REQUIRED. JSON array as defined in Appendix E.1.3.2. This claim contains the type values the Wallet shall request in the subsequent Credential Request.
+  };
+}
+
+export type CredentialOfferFormat = CommonCredentialOfferFormat & (CredentialOfferFormatJwtVcJson | CredentialOfferFormatJwtVcJsonLdAndLdpVc);
 
 export interface IssuerCredentialDefinition {
   '@context': ICredentialContextType[];
   types: string[];
-  credentialSubject: IssuerCredentialSubject;
+  credentialSubject?: IssuerCredentialSubject;
 }
 
 /*

--- a/packages/issuer-rest/lib/__tests__/ClientIssuerIT.spec.ts
+++ b/packages/issuer-rest/lib/__tests__/ClientIssuerIT.spec.ts
@@ -288,8 +288,10 @@ describe('VcIssuer', () => {
     }
 
     const credentialResponse = await client.acquireCredentials({
-      credentialTypes: ['VerifiableCredential'],
-      format: 'jwt_vc_json',
+      requestInput: {
+        format: 'jwt_vc_json',
+        types: ['VerifiableCredential'],
+      },
       proofCallbacks: { signCallback: proofOfPossessionCallbackFunction },
     })
     expect(credentialResponse).toMatchObject({


### PR DESCRIPTION
This PR adds support for inline credential offers in the `credentials` property of an v11 credential offer. An inline offer does not map to any supported credential in the issuer metadata.

With the new methods etc. how you can use it is as follows:
- call `getOfferedCredentialsWithMetadata` on the client. This returns a list of `CredentialSupported` or `CredentialOfferFormat`.
- call `acquireCredentials...` and you provide the `types` and `format` from either the `CredentialsSupported` or the `CredentialOfferFormat`.

This prevents a lot of version checking and having to access a lot of internal data structures on our side.


Some notes on the implementation:
- We could try to fit the `CredentialOfferFormat` into something like a `CredentialSupported` structure (a common structure between both) to make it easier for the user of the library to work with inline offers, but I think this would only add complexity to the interface of the library, and there's no guarantee for the objects to have overlap.
- I'm quite confused by inline credential offers, as I don't see how you can infer what crypto suites, did methods, etc.. are supported by the issuer for an inline credential offer.
- I'm quite confused by the way a credential request works as you request based on the `types` and `format` (which are both present in the `CredentialSupported` and `CredentiaOfferFormat`). What I don't get is why the credential request (this is about the spec) doesn't just accept an `id` of the credential as is used in the credentials supported. This makes it quite ambiguous which credential you're requesting IMO.

I've also made some improvements to the mapping of the v8 structure to v11 and included an `id` for all the objects based on the key that was used in v8.

So a v8 structure of this:

```ts
OpenBadgeCredential: {
        formats: {
          ldp_vc: {
            name: 'JFF x vc-edu PlugFest 2',
            description: "MATTR's submission for JFF Plugfest 2",
            types: ['OpenBadgeCredential'],
            binding_methods_supported: ['did'],
            cryptographic_suites_supported: ['Ed25519Signature2018'],
          },
        jwt_vc: {
            name: 'JFF x vc-edu PlugFest 2',
            description: "MATTR's submission for JFF Plugfest 2",
            types: ['OpenBadgeCredential'],
            binding_methods_supported: ['did'],
            cryptographic_suites_supported: ['EdDSA'],
          },
        },
      },
```

is now transformed to (approximation):

```ts
[
 {
           id: 'OpenBadgeCredential-ldp_vc',
            name: 'JFF x vc-edu PlugFest 2',
            description: "MATTR's submission for JFF Plugfest 2",
            types: ['OpenBadgeCredential'],
            binding_methods_supported: ['did'],
            cryptographic_suites_supported: ['Ed25519Signature2018']
},
{
           id: 'OpenBadgeCredential-jwt_vc',
            name: 'JFF x vc-edu PlugFest 2',
            description: "MATTR's submission for JFF Plugfest 2",
            types: ['OpenBadgeCredential'],
            binding_methods_supported: ['did'],
            cryptographic_suites_supported: ['EdDSA']
}
]
```


This makes it possible to find the supported credential based on the id used in the credential offer. To help with the id having a suffix, there's a new `getCredentialsSupportedById`, which takes this id conflict into account.

Furthermore, there seemed to be a mix up of the credential types (between the `types` property  and the `id` from credentials offered/supported). This is my attempt to fix it.


I haven't added tests as I first want some feedback on the approach.