### PR TITLE
Feature/enable authorization code flow helpers

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -57,7 +57,6 @@ import { OpenID4VCIClient } from '@sphereon/oid4vci-client';
 // The client is initiated from a URI. This URI is provided by the Issuer, typically as a URL or QR code.
 const client = await OpenID4VCIClient.fromURI({
   uri: 'openid-initiate-issuance://?issuer=https%3A%2F%2Fissuer.research.identiproof.io&credential_type=OpenBadgeCredentialUrl&pre-authorized_code=4jLs9xZHEfqcoow0kHE7d1a8hUk6Sy-5bVSV2MqBUGUgiFFQi-ImL62T-FmLIo8hKA1UdMPH0lM1xAgcFkJfxIw9L-lI3mVs0hRT8YVwsEM1ma6N3wzuCdwtMU4bcwKp&user_pin_required=true',
-  flowType: AuthzFlowType.PRE_AUTHORIZED_CODE_FLOW, // The flow to use
   kid: 'did:example:ebfeb1f712ebc6f1c276e12ec21#key-1', // Our DID.  You can defer this also to when the acquireCredential method is called
   alg: Alg.ES256, // The signing Algorithm we will use. You can defer this also to when the acquireCredential method is called
   clientId: 'test-clientId', // The clientId if the Authrozation Service requires it.  If a clientId is needed you can defer this also to when the acquireAccessToken method is called

--- a/packages/client/lib/OpenID4VCIClient.ts
+++ b/packages/client/lib/OpenID4VCIClient.ts
@@ -116,13 +116,16 @@ export class OpenID4VCIClient {
 
     const queryObj: { [key: string]: string } = {
       response_type: ResponseType.AUTH_CODE,
-      client_id: this.clientId || '',
       code_challenge_method: codeChallengeMethod,
       code_challenge: codeChallenge,
       authorization_details: JSON.stringify(this.handleAuthorizationDetails(authorizationDetails)),
       redirect_uri: redirectUri,
       scope: scope,
     };
+
+    if (this.clientId) {
+      queryObj['client_id'] = this.clientId;
+    }
 
     if (this.credentialOffer.issuerState) {
       queryObj['issuer_state'] = this.credentialOffer.issuerState;
@@ -167,13 +170,16 @@ export class OpenID4VCIClient {
 
     const queryObj: { [key: string]: string } = {
       response_type: ResponseType.AUTH_CODE,
-      client_id: this.clientId || '',
       code_challenge_method: codeChallengeMethod,
       code_challenge: codeChallenge,
       authorization_details: JSON.stringify(this.handleAuthorizationDetails(authorizationDetails)),
       redirect_uri: redirectUri,
       scope: scope,
     };
+
+    if (this.clientId) {
+      queryObj['client_id'] = this.clientId;
+    }
 
     if (this.credentialOffer.issuerState) {
       queryObj['issuer_state'] = this.credentialOffer.issuerState;

--- a/packages/client/lib/__tests__/AccessTokenClient.spec.ts
+++ b/packages/client/lib/__tests__/AccessTokenClient.spec.ts
@@ -1,11 +1,4 @@
-import {
-  AccessTokenRequest,
-  AccessTokenRequestOpts,
-  AccessTokenResponse,
-  GrantTypes,
-  OpenIDResponse,
-  WellKnownEndpoints,
-} from '@sphereon/oid4vci-common';
+import { AccessTokenRequest, AccessTokenResponse, GrantTypes, OpenIDResponse, WellKnownEndpoints } from '@sphereon/oid4vci-common';
 import nock from 'nock';
 
 import { AccessTokenClient } from '../AccessTokenClient';
@@ -202,24 +195,6 @@ describe('AccessTokenClient should', () => {
         pin: '1234',
       }),
     ).rejects.toThrow(Error('Cannot set a pin, when the pin is not required.'));
-  });
-
-  it('get error if code_verifier is present when flow type is pre-authorized', async () => {
-    const accessTokenClient: AccessTokenClient = new AccessTokenClient();
-
-    nock(MOCK_URL).post(/.*/).reply(200, {});
-
-    const requestOpts: AccessTokenRequestOpts = {
-      credentialOffer: INITIATION_TEST,
-      pin: undefined,
-      codeVerifier: 'RylyWGQ-dzpObnEcoMBDIH9cTAwZXk1wYzktKxsOFgA',
-      code: 'LWCt225yj7gzT2cWeMP4hXj4B4oIYkEiGs4T6pfez91',
-      redirectUri: 'http://example.com/cb',
-    };
-
-    await expect(() => accessTokenClient.acquireAccessToken(requestOpts)).rejects.toThrow(
-      Error('Cannot pass a code_verifier when flow type is pre-authorized'),
-    );
   });
 
   it('get error if no as, issuer and metadata values are present', async () => {

--- a/packages/client/lib/__tests__/IT.spec.ts
+++ b/packages/client/lib/__tests__/IT.spec.ts
@@ -1,7 +1,6 @@
 import {
   AccessTokenResponse,
   Alg,
-  AuthzFlowType,
   CredentialOfferRequestWithBaseUrl,
   Jwt,
   OpenId4VCIVersion,
@@ -72,7 +71,6 @@ describe('OID4VCI-Client should', () => {
     succeedWithAFullFlowWithClientSetup();
     const client = await OpenID4VCIClient.fromURI({
       uri: INITIATE_QR,
-      flowType: AuthzFlowType.PRE_AUTHORIZED_CODE_FLOW,
       kid: 'did:example:ebfeb1f712ebc6f1c276e12ec21/keys/1',
       alg: Alg.ES256,
       clientId: 'test-clientId',
@@ -84,7 +82,6 @@ describe('OID4VCI-Client should', () => {
     succeedWithAFullFlowWithClientSetup();
     const client = await OpenID4VCIClient.fromURI({
       uri: OFFER_QR,
-      flowType: AuthzFlowType.PRE_AUTHORIZED_CODE_FLOW,
       kid: 'did:example:ebfeb1f712ebc6f1c276e12ec21/keys/1',
       alg: Alg.ES256,
       clientId: 'test-clientId',
@@ -93,7 +90,6 @@ describe('OID4VCI-Client should', () => {
   });
 
   async function assertionOfsucceedWithAFullFlowWithClient(client: OpenID4VCIClient) {
-    expect(client.flowType).toEqual(AuthzFlowType.PRE_AUTHORIZED_CODE_FLOW);
     expect(client.credentialOffer).toBeDefined();
     expect(client.endpointMetadata).toBeDefined();
     expect(client.getIssuer()).toEqual('https://issuer.research.identiproof.io');

--- a/packages/client/lib/__tests__/MattrE2E.spec.test.ts
+++ b/packages/client/lib/__tests__/MattrE2E.spec.test.ts
@@ -1,4 +1,4 @@
-import { Alg, AuthzFlowType, Jwt } from '@sphereon/oid4vci-common';
+import { Alg, Jwt } from '@sphereon/oid4vci-common';
 import { CredentialMapper } from '@sphereon/ssi-types';
 import { fetch } from 'cross-fetch';
 import { importJWK, JWK, SignJWT } from 'jose';
@@ -25,11 +25,9 @@ describe('OID4VCI-Client using Mattr issuer should', () => {
     const offer = await getCredentialOffer(format);
     const client = await OpenID4VCIClient.fromURI({
       uri: offer.offerUrl,
-      flowType: AuthzFlowType.PRE_AUTHORIZED_CODE_FLOW,
       kid,
       alg: Alg.EdDSA,
     });
-    expect(client.flowType).toEqual(AuthzFlowType.PRE_AUTHORIZED_CODE_FLOW);
     expect(client.credentialOffer).toBeDefined();
     expect(client.endpointMetadata).toBeDefined();
     expect(client.getCredentialEndpoint()).toEqual(`${ISSUER_URL}/oidc/v1/auth/credential`);

--- a/packages/client/lib/__tests__/OpenID4VCIClient.spec.ts
+++ b/packages/client/lib/__tests__/OpenID4VCIClient.spec.ts
@@ -1,4 +1,4 @@
-import { AuthzFlowType, CodeChallengeMethod, WellKnownEndpoints } from '@sphereon/oid4vci-common';
+import { CodeChallengeMethod, WellKnownEndpoints } from '@sphereon/oid4vci-common';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import nock from 'nock';
@@ -15,8 +15,8 @@ describe('OpenID4VCIClient should', () => {
     nock(MOCK_URL).get(WellKnownEndpoints.OAUTH_AS).reply(404, {});
     nock(MOCK_URL).get(WellKnownEndpoints.OPENID_CONFIGURATION).reply(404, {});
     client = await OpenID4VCIClient.fromURI({
+      clientId: 'test-client',
       uri: 'openid-initiate-issuance://?issuer=https://server.example.com&credential_type=TestCredential',
-      flowType: AuthzFlowType.AUTHORIZATION_CODE_FLOW,
     });
   });
 
@@ -29,7 +29,6 @@ describe('OpenID4VCIClient should', () => {
     // @ts-ignore
     client._endpointMetadata?.credentialIssuerMetadata.authorization_endpoint = `${MOCK_URL}v1/auth/authorize`;
     const url = client.createAuthorizationRequestUrl({
-      clientId: 'test-client',
       codeChallengeMethod: CodeChallengeMethod.SHA256,
       codeChallenge: 'mE2kPHmIprOqtkaYmESWj35yz-PB5vzdiSu0tAZ8sqs',
       scope: 'openid TestCredential',
@@ -44,7 +43,6 @@ describe('OpenID4VCIClient should', () => {
   it('throw an error if authorization endpoint is not set in server metadata', async () => {
     expect(() => {
       client.createAuthorizationRequestUrl({
-        clientId: 'test-client',
         codeChallengeMethod: CodeChallengeMethod.SHA256,
         codeChallenge: 'mE2kPHmIprOqtkaYmESWj35yz-PB5vzdiSu0tAZ8sqs',
         scope: 'openid TestCredential',
@@ -58,7 +56,6 @@ describe('OpenID4VCIClient should', () => {
     client._endpointMetadata?.credentialIssuerMetadata.authorization_endpoint = `${MOCK_URL}v1/auth/authorize`;
 
     const url = client.createAuthorizationRequestUrl({
-      clientId: 'test-client',
       codeChallengeMethod: CodeChallengeMethod.SHA256,
       codeChallenge: 'mE2kPHmIprOqtkaYmESWj35yz-PB5vzdiSu0tAZ8sqs',
       scope: 'TestCredential',
@@ -77,7 +74,6 @@ describe('OpenID4VCIClient should', () => {
 
     expect(() => {
       client.createAuthorizationRequestUrl({
-        clientId: 'test-client',
         codeChallengeMethod: CodeChallengeMethod.SHA256,
         codeChallenge: 'mE2kPHmIprOqtkaYmESWj35yz-PB5vzdiSu0tAZ8sqs',
         redirectUri: 'http://localhost:8881/cb',
@@ -91,7 +87,6 @@ describe('OpenID4VCIClient should', () => {
 
     expect(
       client.createAuthorizationRequestUrl({
-        clientId: 'test-client',
         codeChallengeMethod: CodeChallengeMethod.SHA256,
         codeChallenge: 'mE2kPHmIprOqtkaYmESWj35yz-PB5vzdiSu0tAZ8sqs',
         authorizationDetails: [
@@ -112,7 +107,7 @@ describe('OpenID4VCIClient should', () => {
         redirectUri: 'http://localhost:8881/cb',
       }),
     ).toEqual(
-      'https://server.example.com/v1/auth/authorize?response_type=code&client_id=test-client&code_challenge_method=S256&code_challenge=mE2kPHmIprOqtkaYmESWj35yz-PB5vzdiSu0tAZ8sqs&authorization_details=%5B%7B%22type%22%3A%22openid_credential%22%2C%22format%22%3A%22ldp_vc%22%2C%22credential_definition%22%3A%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww%2Ew3%2Eorg%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fwww%2Ew3%2Eorg%2F2018%2Fcredentials%2Fexamples%2Fv1%22%5D%2C%22types%22%3A%5B%22VerifiableCredential%22%2C%22UniversityDegreeCredential%22%5D%7D%2C%22locations%22%3A%22https%3A%2F%2Fserver%2Eexample%2Ecom%22%7D%2C%7B%22type%22%3A%22openid_credential%22%2C%22format%22%3A%22mso_mdoc%22%2C%22doctype%22%3A%22org%2Eiso%2E18013%2E5%2E1%2EmDL%22%2C%22locations%22%3A%22https%3A%2F%2Fserver%2Eexample%2Ecom%22%7D%5D&redirect_uri=http%3A%2F%2Flocalhost%3A8881%2Fcb',
+      'https://server.example.com/v1/auth/authorize?response_type=code&client_id=test-client&code_challenge_method=S256&code_challenge=mE2kPHmIprOqtkaYmESWj35yz-PB5vzdiSu0tAZ8sqs&authorization_details=%5B%7B%22type%22%3A%22openid_credential%22%2C%22format%22%3A%22ldp_vc%22%2C%22credential_definition%22%3A%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww%2Ew3%2Eorg%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fwww%2Ew3%2Eorg%2F2018%2Fcredentials%2Fexamples%2Fv1%22%5D%2C%22types%22%3A%5B%22VerifiableCredential%22%2C%22UniversityDegreeCredential%22%5D%7D%2C%22locations%22%3A%22https%3A%2F%2Fserver%2Eexample%2Ecom%22%7D%2C%7B%22type%22%3A%22openid_credential%22%2C%22format%22%3A%22mso_mdoc%22%2C%22doctype%22%3A%22org%2Eiso%2E18013%2E5%2E1%2EmDL%22%2C%22locations%22%3A%22https%3A%2F%2Fserver%2Eexample%2Ecom%22%7D%5D&redirect_uri=http%3A%2F%2Flocalhost%3A8881%2Fcb&scope=openid',
     );
   });
   it('create an authorization request url with authorization_details object property', async () => {
@@ -122,7 +117,6 @@ describe('OpenID4VCIClient should', () => {
 
     expect(
       client.createAuthorizationRequestUrl({
-        clientId: 'test-client',
         codeChallengeMethod: CodeChallengeMethod.SHA256,
         codeChallenge: 'mE2kPHmIprOqtkaYmESWj35yz-PB5vzdiSu0tAZ8sqs',
         authorizationDetails: {
@@ -136,7 +130,7 @@ describe('OpenID4VCIClient should', () => {
         redirectUri: 'http://localhost:8881/cb',
       }),
     ).toEqual(
-      'https://server.example.com/v1/auth/authorize?response_type=code&client_id=test-client&code_challenge_method=S256&code_challenge=mE2kPHmIprOqtkaYmESWj35yz-PB5vzdiSu0tAZ8sqs&authorization_details=%7B%22type%22%3A%22openid_credential%22%2C%22format%22%3A%22ldp_vc%22%2C%22credential_definition%22%3A%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww%2Ew3%2Eorg%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fwww%2Ew3%2Eorg%2F2018%2Fcredentials%2Fexamples%2Fv1%22%5D%2C%22types%22%3A%5B%22VerifiableCredential%22%2C%22UniversityDegreeCredential%22%5D%7D%2C%22locations%22%3A%22https%3A%2F%2Fserver%2Eexample%2Ecom%22%7D&redirect_uri=http%3A%2F%2Flocalhost%3A8881%2Fcb',
+      'https://server.example.com/v1/auth/authorize?response_type=code&client_id=test-client&code_challenge_method=S256&code_challenge=mE2kPHmIprOqtkaYmESWj35yz-PB5vzdiSu0tAZ8sqs&authorization_details=%7B%22type%22%3A%22openid_credential%22%2C%22format%22%3A%22ldp_vc%22%2C%22credential_definition%22%3A%7B%22%40context%22%3A%5B%22https%3A%2F%2Fwww%2Ew3%2Eorg%2F2018%2Fcredentials%2Fv1%22%2C%22https%3A%2F%2Fwww%2Ew3%2Eorg%2F2018%2Fcredentials%2Fexamples%2Fv1%22%5D%2C%22types%22%3A%5B%22VerifiableCredential%22%2C%22UniversityDegreeCredential%22%5D%7D%2C%22locations%22%3A%22https%3A%2F%2Fserver%2Eexample%2Ecom%22%7D&redirect_uri=http%3A%2F%2Flocalhost%3A8881%2Fcb&scope=openid',
     );
   });
   it('create an authorization request url with authorization_details and scope', async () => {
@@ -146,7 +140,6 @@ describe('OpenID4VCIClient should', () => {
 
     expect(
       client.createAuthorizationRequestUrl({
-        clientId: 'test-client',
         codeChallengeMethod: CodeChallengeMethod.SHA256,
         codeChallenge: 'mE2kPHmIprOqtkaYmESWj35yz-PB5vzdiSu0tAZ8sqs',
         authorizationDetails: {

--- a/packages/common/lib/functions/Encoding.ts
+++ b/packages/common/lib/functions/Encoding.ts
@@ -1,4 +1,4 @@
-import { BAD_PARAMS, DecodeURIAsJsonOpts, EncodeJsonAsURIOpts, OpenId4VCIVersion, SearchValue } from '../types';
+import { BAD_PARAMS, DecodeURIAsJsonOpts, EncodeJsonAsURIOpts, SearchValue } from '../types';
 
 /**
  * @function encodeJsonAsURI encodes a Json object into a URI
@@ -29,39 +29,35 @@ export function convertJsonToURI(
     return encodeURIComponent(key.replace(' ', ''));
   }
 
-  let components: string;
-  if (opts?.version && opts.version > OpenId4VCIVersion.VER_1_0_08) {
-    // v11 changed from encoding every param to a encoded json object with a credential_offer param key
-    components = encodeAndStripWhitespace(JSON.stringify(json));
-  } else {
-    for (const [key, value] of Object.entries(json)) {
-      if (!value) {
-        continue;
-      }
-      //Skip properties that are not of URL type
-      if (!opts?.uriTypeProperties?.includes(key)) {
-        results.push(`${key}=${value}`);
-        continue;
-      }
-      if (opts?.arrayTypeProperties?.includes(key) && Array.isArray(value)) {
-        results.push(value.map((v) => `${encodeAndStripWhitespace(key)}=${customEncodeURIComponent(v, /\./g)}`).join('&'));
-        continue;
-      }
-      const isBool = typeof value == 'boolean';
-      const isNumber = typeof value == 'number';
-      const isString = typeof value == 'string';
-      let encoded;
-      if (isBool || isNumber) {
-        encoded = `${encodeAndStripWhitespace(key)}=${value}`;
-      } else if (isString) {
-        encoded = `${encodeAndStripWhitespace(key)}=${customEncodeURIComponent(value, /\./g)}`;
-      } else {
-        encoded = `${encodeAndStripWhitespace(key)}=${customEncodeURIComponent(JSON.stringify(value), /\./g)}`;
-      }
-      results.push(encoded);
+  for (const [key, value] of Object.entries(json)) {
+    if (!value) {
+      continue;
     }
-    components = results.join('&');
+    //Skip properties that are not of URL type
+    if (!opts?.uriTypeProperties?.includes(key)) {
+      results.push(`${key}=${value}`);
+      continue;
+    }
+    if (opts?.arrayTypeProperties?.includes(key) && Array.isArray(value)) {
+      results.push(value.map((v) => `${encodeAndStripWhitespace(key)}=${customEncodeURIComponent(v, /\./g)}`).join('&'));
+      continue;
+    }
+    const isBool = typeof value == 'boolean';
+    const isNumber = typeof value == 'number';
+    const isString = typeof value == 'string';
+    let encoded;
+    if (isBool || isNumber) {
+      encoded = `${encodeAndStripWhitespace(key)}=${value}`;
+    } else if (isString) {
+      encoded = `${encodeAndStripWhitespace(key)}=${customEncodeURIComponent(value, /\./g)}`;
+    } else {
+      encoded = `${encodeAndStripWhitespace(key)}=${customEncodeURIComponent(JSON.stringify(value), /\./g)}`;
+    }
+    results.push(encoded);
   }
+
+  const components = results.join('&');
+
   if (opts?.baseUrl) {
     if (opts.baseUrl.endsWith('=')) {
       if (opts.param) {

--- a/packages/common/lib/functions/Encoding.ts
+++ b/packages/common/lib/functions/Encoding.ts
@@ -1,4 +1,4 @@
-import { BAD_PARAMS, DecodeURIAsJsonOpts, EncodeJsonAsURIOpts, SearchValue } from '../types';
+import { BAD_PARAMS, DecodeURIAsJsonOpts, EncodeJsonAsURIOpts, OpenId4VCIVersion, SearchValue } from '../types';
 
 /**
  * @function encodeJsonAsURI encodes a Json object into a URI
@@ -29,35 +29,39 @@ export function convertJsonToURI(
     return encodeURIComponent(key.replace(' ', ''));
   }
 
-  for (const [key, value] of Object.entries(json)) {
-    if (!value) {
-      continue;
+  let components: string;
+  if (opts?.version && opts.version > OpenId4VCIVersion.VER_1_0_08) {
+    // v11 changed from encoding every param to a encoded json object with a credential_offer param key
+    components = encodeAndStripWhitespace(JSON.stringify(json));
+  } else {
+    for (const [key, value] of Object.entries(json)) {
+      if (!value) {
+        continue;
+      }
+      //Skip properties that are not of URL type
+      if (!opts?.uriTypeProperties?.includes(key)) {
+        results.push(`${key}=${value}`);
+        continue;
+      }
+      if (opts?.arrayTypeProperties?.includes(key) && Array.isArray(value)) {
+        results.push(value.map((v) => `${encodeAndStripWhitespace(key)}=${customEncodeURIComponent(v, /\./g)}`).join('&'));
+        continue;
+      }
+      const isBool = typeof value == 'boolean';
+      const isNumber = typeof value == 'number';
+      const isString = typeof value == 'string';
+      let encoded;
+      if (isBool || isNumber) {
+        encoded = `${encodeAndStripWhitespace(key)}=${value}`;
+      } else if (isString) {
+        encoded = `${encodeAndStripWhitespace(key)}=${customEncodeURIComponent(value, /\./g)}`;
+      } else {
+        encoded = `${encodeAndStripWhitespace(key)}=${customEncodeURIComponent(JSON.stringify(value), /\./g)}`;
+      }
+      results.push(encoded);
     }
-    //Skip properties that are not of URL type
-    if (!opts?.uriTypeProperties?.includes(key)) {
-      results.push(`${key}=${value}`);
-      continue;
-    }
-    if (opts?.arrayTypeProperties?.includes(key) && Array.isArray(value)) {
-      results.push(value.map((v) => `${encodeAndStripWhitespace(key)}=${customEncodeURIComponent(v, /\./g)}`).join('&'));
-      continue;
-    }
-    const isBool = typeof value == 'boolean';
-    const isNumber = typeof value == 'number';
-    const isString = typeof value == 'string';
-    let encoded;
-    if (isBool || isNumber) {
-      encoded = `${encodeAndStripWhitespace(key)}=${value}`;
-    } else if (isString) {
-      encoded = `${encodeAndStripWhitespace(key)}=${customEncodeURIComponent(value, /\./g)}`;
-    } else {
-      encoded = `${encodeAndStripWhitespace(key)}=${customEncodeURIComponent(JSON.stringify(value), /\./g)}`;
-    }
-    results.push(encoded);
+    components = results.join('&');
   }
-
-  const components = results.join('&');
-
   if (opts?.baseUrl) {
     if (opts.baseUrl.endsWith('=')) {
       if (opts.param) {

--- a/packages/issuer-rest/lib/__tests__/ClientIssuerIT.spec.ts
+++ b/packages/issuer-rest/lib/__tests__/ClientIssuerIT.spec.ts
@@ -5,7 +5,6 @@ import { OpenID4VCIClient } from '@sphereon/oid4vci-client'
 import {
   AccessTokenResponse,
   Alg,
-  AuthzFlowType,
   CredentialOfferSession,
   CredentialSupported,
   IssuerCredentialSubjectDisplay,
@@ -207,7 +206,6 @@ describe('VcIssuer', () => {
   it('should create client from credential offer URI', async () => {
     client = await OpenID4VCIClient.fromURI({
       uri,
-      flowType: AuthzFlowType.PRE_AUTHORIZED_CODE_FLOW,
       kid: subjectDIDKey.didDocument.authentication[0],
       alg: 'ES256',
     })

--- a/packages/issuer/lib/__tests__/VcIssuer.spec.ts
+++ b/packages/issuer/lib/__tests__/VcIssuer.spec.ts
@@ -1,7 +1,6 @@
 import { OpenID4VCIClient } from '@sphereon/oid4vci-client'
 import {
   Alg,
-  AuthzFlowType,
   CredentialOfferLdpVcV1_0_11,
   CredentialOfferSession,
   CredentialSupported,
@@ -153,7 +152,7 @@ describe('VcIssuer', () => {
       'http://issuer-example.com?credential_offer=%7B%22grants%22%3A%7B%22authorization_code%22%3A%7B%22issuer_state%22%3A%22previously-created-state%22%7D%2C%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%22test_code%22%2C%22user_pin_required%22%3Atrue%7D%7D%2C%22credential_issuer%22%3A%22https%3A%2F%2Fissuer.research.identiproof.io%22%2C%22credentials%22%3A%5B%7B%22format%22%3A%22jwt_vc_json%22%2C%22types%22%3A%5B%22VerifiableCredential%22%5D%2C%22credentialSubject%22%3A%7B%22given_name%22%3A%7B%22name%22%3A%22given%20name%22%2C%22locale%22%3A%22en-US%22%7D%7D%2C%22cryptographic_suites_supported%22%3A%5B%22ES256K%22%5D%2C%22cryptographic_binding_methods_supported%22%3A%5B%22did%22%5D%2C%22id%22%3A%22UniversityDegree_JWT%22%2C%22display%22%3A%5B%7B%22name%22%3A%22University%20Credential%22%2C%22locale%22%3A%22en-US%22%2C%22logo%22%3A%7B%22url%22%3A%22https%3A%2F%2Fexampleuniversity.com%2Fpublic%2Flogo.png%22%2C%22alt_text%22%3A%22a%20square%20logo%20of%20a%20university%22%7D%2C%22background_color%22%3A%22%2312107c%22%2C%22text_color%22%3A%22%23FFFFFF%22%7D%5D%7D%5D%7D',
     )
 
-    const client = await OpenID4VCIClient.fromURI({ uri, flowType: AuthzFlowType.PRE_AUTHORIZED_CODE_FLOW })
+    const client = await OpenID4VCIClient.fromURI({ uri })
     expect(client.credentialOffer).toEqual({
       baseUrl: 'http://issuer-example.com',
       credential_offer: {


### PR DESCRIPTION
- Removes checks so library could as well help with authorization code flow.
- Removed `flowType` parameter `OpenID4VCIClient`.
- Updated `acquirePushedAuthorizationRequestURI` method to return a complete authorization URL that can be opened by the client. Just like `createAuthorizationRequestUrl` does.
- Use `clientId` that was passed when constructing `OpenID4VCIClient` in subsequent calls.