### PR TITLE
feat: add sd-jwt support

### DIFF
--- a/packages/callback-example/lib/__tests__/issuerCallback.spec.ts
+++ b/packages/callback-example/lib/__tests__/issuerCallback.spec.ts
@@ -4,7 +4,6 @@ import { CredentialRequestClient, CredentialRequestClientBuilder, ProofOfPossess
 import {
   Alg,
   CNonceState,
-  CredentialOfferLdpVcV1_0_11,
   CredentialSupported,
   IssuerCredentialSubjectDisplay,
   IssueStatus,
@@ -118,11 +117,16 @@ describe('issuerCallback', () => {
       credentialOffer: {
         credential_offer: {
           credential_issuer: 'did:key:test',
-          credential_definition: {
-            types: ['VerifiableCredential'],
-            '@context': ['https://www.w3.org/2018/credentials/v1'],
-            credentialSubject: {},
-          },
+          credentials: [
+            {
+              format: 'ldp_vc',
+              credential_definition: {
+                types: ['VerifiableCredential'],
+                '@context': ['https://www.w3.org/2018/credentials/v1'],
+                credentialSubject: {},
+              },
+            },
+          ],
           grants: {
             authorization_code: { issuer_state: 'test_code' },
             'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
@@ -130,7 +134,7 @@ describe('issuerCallback', () => {
               user_pin_required: true,
             },
           },
-        } as CredentialOfferLdpVcV1_0_11,
+        },
       },
     })
 

--- a/packages/client/lib/AuthorizationDetailsBuilder.ts
+++ b/packages/client/lib/AuthorizationDetailsBuilder.ts
@@ -1,8 +1,8 @@
-import { AuthorizationDetailsJwtVcJson, OID4VCICredentialFormat } from '@sphereon/oid4vci-common';
+import { AuthorizationDetails, AuthorizationDetailsJwtVcJson, OID4VCICredentialFormat } from '@sphereon/oid4vci-common';
 
 //todo: refactor this builder to be able to create ldp details as well
 export class AuthorizationDetailsBuilder {
-  private readonly authorizationDetails: Partial<AuthorizationDetailsJwtVcJson>;
+  private readonly authorizationDetails: Partial<Exclude<AuthorizationDetails, string>>;
 
   constructor() {
     this.authorizationDetails = {};

--- a/packages/client/lib/CredentialRequestClientBuilder.ts
+++ b/packages/client/lib/CredentialRequestClientBuilder.ts
@@ -6,6 +6,7 @@ import {
   determineSpecVersionFromOffer,
   EndpointMetadata,
   getIssuerFromCredentialOfferPayload,
+  getTypesFromOffer,
   OID4VCICredentialFormat,
   OpenId4VCIVersion,
   UniformCredentialOfferRequest,
@@ -46,7 +47,7 @@ export class CredentialRequestClientBuilder {
       builder.withCredentialType((request.original_credential_offer as CredentialOfferPayloadV1_0_08).credential_type);
     } else {
       // todo: look whether this is correct
-      builder.withCredentialType(request.credential_offer.credentials.flatMap((c) => (typeof c === 'string' ? c : c.types)));
+      builder.withCredentialType(getTypesFromOffer(request.credential_offer));
     }
 
     return builder;

--- a/packages/client/lib/__tests__/CredentialRequestClient.spec.ts
+++ b/packages/client/lib/__tests__/CredentialRequestClient.spec.ts
@@ -3,6 +3,7 @@ import { KeyObject } from 'crypto';
 import {
   Alg,
   EndpointMetadata,
+  getCredentialRequestForVersion,
   getIssuerFromCredentialOfferPayload,
   Jwt,
   OpenId4VCIVersion,
@@ -149,9 +150,7 @@ describe('Credential Request Client ', () => {
       .withKid(kid)
       .withClientId('sphereon:wallet')
       .build();
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    await expect(credReqClient.acquireCredentialsUsingRequest({ format: 'jwt_vc_json-ld', types: ['random'], proof })).rejects.toThrow(
+    await expect(credReqClient.acquireCredentialsUsingRequest({ format: 'jwt_vc_json', types: ['random'], proof })).rejects.toThrow(
       Error(URL_NOT_VALID),
     );
   });
@@ -194,10 +193,11 @@ describe('Credential Request Client with different issuers ', () => {
           jwt: getMockData('spruce')?.credential.request.proof.jwt as string,
         },
         credentialTypes: ['OpenBadgeCredential'],
-        format: 'jwt_vc_json-ld',
+        format: 'jwt_vc',
         version: OpenId4VCIVersion.VER_1_0_08,
       });
-    expect(credentialRequest).toEqual(getMockData('spruce')?.credential.request);
+    const draft8CredentialRequest = getCredentialRequestForVersion(credentialRequest, OpenId4VCIVersion.VER_1_0_08);
+    expect(draft8CredentialRequest).toEqual(getMockData('spruce')?.credential.request);
   });
 
   it('should create correct CredentialRequest for Walt', async () => {
@@ -264,7 +264,8 @@ describe('Credential Request Client with different issuers ', () => {
         format: 'ldp_vc',
         version: OpenId4VCIVersion.VER_1_0_08,
       });
-    expect(credentialOffer).toEqual(getMockData('mattr')?.credential.request);
+    const credentialRequest = getCredentialRequestForVersion(credentialOffer, OpenId4VCIVersion.VER_1_0_08);
+    expect(credentialRequest).toEqual(getMockData('mattr')?.credential.request);
   });
 
   it('should create correct CredentialRequest for diwala', async () => {
@@ -286,6 +287,10 @@ describe('Credential Request Client with different issuers ', () => {
         format: 'ldp_vc',
         version: OpenId4VCIVersion.VER_1_0_08,
       });
-    expect(credentialOffer).toEqual(getMockData('diwala')?.credential.request);
+
+    // createCredentialRequest returns uniform format in draft 11
+    const credentialRequest = getCredentialRequestForVersion(credentialOffer, OpenId4VCIVersion.VER_1_0_08);
+
+    expect(credentialRequest).toEqual(getMockData('diwala')?.credential.request);
   });
 });

--- a/packages/client/lib/__tests__/data/VciDataFixtures.ts
+++ b/packages/client/lib/__tests__/data/VciDataFixtures.ts
@@ -1,4 +1,4 @@
-import { CredentialSupportedBrief, IssuerCredentialSubjectDisplay, IssuerMetadataV1_0_08 } from '@sphereon/oid4vci-common';
+import { CredentialSupportedFormatV1_0_08, IssuerCredentialSubjectDisplay, IssuerMetadataV1_0_08 } from '@sphereon/oid4vci-common';
 import { ICredentialStatus, W3CVerifiableCredential } from '@sphereon/ssi-types';
 
 export function getMockData(issuerName: string): IssuerMockData | null {
@@ -42,7 +42,8 @@ export interface IssuerMockData {
     url: string;
     deeplink: string;
     request: {
-      types: [string];
+      types?: [string];
+      type?: string;
       format: 'jwt_vc' | 'ldp_vc' | 'jwt_vc_json-ld' | string;
       proof: {
         proof_type: 'jwt' | string;
@@ -110,8 +111,8 @@ const mockData: VciMockDataStructure = {
       deeplink:
         'openid-initiate-issuance://?issuer=https%3A%2F%2Fngi%2Doidc4vci%2Dtest%2Espruceid%2Exyz&credential_type=OpenBadgeCredential&pre-authorized_code=eyJhbGciOiJFUzI1NiJ9.eyJjcmVkZW50aWFsX3R5cGUiOlsiT3BlbkJhZGdlQ3JlZGVudGlhbCJdLCJleHAiOiIyMDIzLTA0LTIwVDA5OjA0OjM2WiIsIm5vbmNlIjoibWFibmVpT0VSZVB3V3BuRFFweEt3UnRsVVRFRlhGUEwifQ.qOZRPN8sTv_knhp7WaWte2-aDULaPZX--2i9unF6QDQNUllqDhvxgIHMDCYHCV8O2_Gj-T2x1J84fDMajE3asg&user_pin_required=false',
       request: {
-        types: ['OpenBadgeCredential'],
-        format: 'jwt_vc_json-ld',
+        type: 'OpenBadgeCredential',
+        format: 'jwt_vc',
         proof: {
           proof_type: 'jwt',
           jwt: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksiLCJraWQiOiJkaWQ6andrOmV5SmhiR2NpT2lKRlV6STFOa3NpTENKMWMyVWlPaUp6YVdjaUxDSnJkSGtpT2lKRlF5SXNJbU55ZGlJNkluTmxZM0F5TlRack1TSXNJbmdpT2lKclpuVmpTa0V0VEhKck9VWjBPRmx5TFVkMlQzSmpia3N3YjNkc2RqUlhNblUwU3pJeFNHZHZTVlIzSWl3aWVTSTZJalozY0ZCUE1rOUNRVXBTU0ZFMVRXdEtXVlJaV0dsQlJFUXdOMU5OTlV0amVXcDNYMkUzVUUxWmVGa2lmUSMwIn0.eyJhdWQiOiJodHRwczovL25naS1vaWRjNHZjaS10ZXN0LnNwcnVjZWlkLnh5eiIsImlhdCI6MTY4MTkxMTA2MC45NDIsImV4cCI6MTY4MTkxMTcyMC45NDIsImlzcyI6InNwaGVyZW9uOnNzaS13YWxsZXQiLCJqdGkiOiJhNjA4MzMxZi02ZmE0LTQ0ZjAtYWNkZWY5NmFjMjdmNmQ3MCJ9.NwF3_41gwnlIdd_6Uk9CczeQHzIQt6UcvTT5Cxv72j9S1vNwiY9annA2kLsjsTiR5-WMBdUhJCO7wYCtZ15mxw',
@@ -514,7 +515,7 @@ const mockData: VciMockDataStructure = {
                 types: ['PermanentResidentCard'],
                 binding_methods_supported: ['did'],
                 cryptographic_suites_supported: ['Ed25519Signature2018'],
-              } as CredentialSupportedBrief,
+              } as CredentialSupportedFormatV1_0_08,
             },
           },
           AcademicAward: {
@@ -525,7 +526,7 @@ const mockData: VciMockDataStructure = {
                 types: ['AcademicAward'],
                 binding_methods_supported: ['did'],
                 cryptographic_suites_supported: ['Ed25519Signature2018'],
-              } as CredentialSupportedBrief,
+              } as CredentialSupportedFormatV1_0_08,
             },
           },
           LearnerProfile: {
@@ -536,7 +537,7 @@ const mockData: VciMockDataStructure = {
                 types: ['LearnerProfile'],
                 binding_methods_supported: ['did'],
                 cryptographic_suites_supported: ['Ed25519Signature2018'],
-              } as CredentialSupportedBrief,
+              } as CredentialSupportedFormatV1_0_08,
             },
           },
           OpenBadgeCredential: {
@@ -547,7 +548,7 @@ const mockData: VciMockDataStructure = {
                 types: ['OpenBadgeCredential'],
                 binding_methods_supported: ['did'],
                 cryptographic_suites_supported: ['Ed25519Signature2018'],
-              } as CredentialSupportedBrief,
+              } as CredentialSupportedFormatV1_0_08,
             },
           },
         },
@@ -573,8 +574,8 @@ const mockData: VciMockDataStructure = {
         'openid-initiate-issuance://?issuer=https://launchpad.mattrlabs.com&credential_type=OpenBadgeCredential&pre-authorized_code=g0UCOj6RAN5AwHU6gczm_GzB4_lH6GW39Z0Dl2DOOiO',
       url: 'https://launchpad.vii.electron.mattrlabs.io/oidc/v1/auth/credential',
       request: {
-        types: ['OpenBadgeCredential'],
-        format: 'jwt_vc_json-ld',
+        type: 'OpenBadgeCredential',
+        format: 'ldp_vc',
         proof: {
           proof_type: 'jwt',
           jwt: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3AxM3N6QUFMVFN0cDV1OGtMcnl5YW5vYWtrVWtFUGZXazdvOHY3dms0RW1KI3o2TWtwMTNzekFBTFRTdHA1dThrTHJ5eWFub2Fra1VrRVBmV2s3bzh2N3ZrNEVtSiJ9.eyJhdWQiOiJodHRwczovL2xhdW5jaHBhZC5tYXR0cmxhYnMuY29tIiwiaWF0IjoxNjgxOTE0NDgyLjUxOSwiZXhwIjoxNjgxOTE1MTQyLjUxOSwiaXNzIjoic3BoZXJlb246c3NpLXdhbGxldCIsImp0aSI6ImI5NDY1ZGE5LTY4OGYtNDdjNi04MjUwNDA0ZGNiOWI5Y2E5In0.uQ8ewOfIjy_1p_Gk6PjeEWccBJnjOca1pwbTWiCAFMQX9wlIsfeUdGtXUoHjH5_PQtpwytodx7WU456_CT9iBQ',
@@ -687,8 +688,8 @@ const mockData: VciMockDataStructure = {
         'openid-initiate-issuance://?issuer=https://oidc4vc.diwala.io&amp;credential_type=OpenBadgeCredential&amp;pre-authorized_code=eyJhbGciOiJIUzI1NiJ9.eyJjcmVkZW50aWFsX3R5cGUiOiJPcGVuQmFkZ2VDcmVkZW50aWFsIiwiZXhwIjoxNjgxOTg0NDY3fQ.fEAHKz2nuWfiYHw406iNxr-81pWkNkbi31bWsYSf6Ng',
       url: 'https://oidc4vc.diwala.io/credential',
       request: {
-        types: ['OpenBadgeCredential'],
-        format: 'jwt_vc_json-ld',
+        type: 'OpenBadgeCredential',
+        format: 'ldp_vc',
         proof: {
           proof_type: 'jwt',
           jwt: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa3AxM3N6QUFMVFN0cDV1OGtMcnl5YW5vYWtrVWtFUGZXazdvOHY3dms0RW1KI3o2TWtwMTNzekFBTFRTdHA1dThrTHJ5eWFub2Fra1VrRVBmV2s3bzh2N3ZrNEVtSiJ9.eyJhdWQiOiJodHRwczovL29pZGM0dmMuZGl3YWxhLmlvIiwiaWF0IjoxNjgxOTE1MDk1LjIwMiwiZXhwIjoxNjgxOTE1NzU1LjIwMiwiaXNzIjoic3BoZXJlb246c3NpLXdhbGxldCIsImp0aSI6IjYxN2MwM2EzLTM3MTUtNGJlMy1hYjkxNzM4MTlmYzYxNTYzIn0.KA-cHjecaYp9FSaWHkz5cqtNyhBIVT_0I7cJnpHn03T4UWFvdhjhn8Hpe-BU247enFyWOWJ6v3NQZyZgle7xBA',

--- a/packages/common/lib/functions/CredentialRequestUtil.ts
+++ b/packages/common/lib/functions/CredentialRequestUtil.ts
@@ -1,7 +1,17 @@
-import { CredentialRequestV1_0_11 } from '../types';
+import { CredentialRequestV1_0_08, OpenId4VCIVersion, UniformCredentialRequest } from '../types';
 
-export function getTypesFromRequest(credentialRequest: CredentialRequestV1_0_11, opts?: { filterVerifiableCredential: boolean }) {
-  const types = 'types' in credentialRequest ? credentialRequest.types : credentialRequest.credential_definition.types;
+import { getFormatForVersion } from './FormatUtils';
+
+export function getTypesFromRequest(credentialRequest: UniformCredentialRequest, opts?: { filterVerifiableCredential: boolean }) {
+  let types: string[] = [];
+  if (credentialRequest.format === 'jwt_vc_json') {
+    types = credentialRequest.types;
+  } else if (credentialRequest.format === 'jwt_vc_json-ld' || credentialRequest.format === 'ldp_vc') {
+    types = credentialRequest.credential_definition.types;
+  } else if (credentialRequest.format === 'vc+sd-jwt') {
+    types = [credentialRequest.credential_definition.vct];
+  }
+
   if (!types || types.length === 0) {
     throw Error('Could not deduce types from credential request');
   }
@@ -9,4 +19,22 @@ export function getTypesFromRequest(credentialRequest: CredentialRequestV1_0_11,
     return types.filter((type) => type !== 'VerifiableCredential');
   }
   return types;
+}
+
+export function getCredentialRequestForVersion(
+  credentialRequest: UniformCredentialRequest,
+  version: OpenId4VCIVersion,
+): UniformCredentialRequest | CredentialRequestV1_0_08 {
+  if (version === OpenId4VCIVersion.VER_1_0_08) {
+    const draft8Format = getFormatForVersion(credentialRequest.format, version);
+    const types = getTypesFromRequest(credentialRequest, { filterVerifiableCredential: true });
+
+    return {
+      format: draft8Format,
+      proof: credentialRequest.proof,
+      type: types[0],
+    } satisfies CredentialRequestV1_0_08;
+  }
+
+  return credentialRequest;
 }

--- a/packages/common/lib/functions/FormatUtils.ts
+++ b/packages/common/lib/functions/FormatUtils.ts
@@ -1,0 +1,52 @@
+import { CredentialFormat } from '@sphereon/ssi-types';
+
+import { OID4VCICredentialFormat, OpenId4VCIVersion } from '../types';
+
+export function isFormat<T extends { format?: OID4VCICredentialFormat }, Format extends OID4VCICredentialFormat>(
+  formatObject: T,
+  format: Format,
+): formatObject is T & { format: Format } {
+  return formatObject.format === format;
+}
+
+export function isNotFormat<T extends { format?: OID4VCICredentialFormat }, Format extends OID4VCICredentialFormat>(
+  formatObject: T,
+  format: Format,
+): formatObject is T & { format: Exclude<OID4VCICredentialFormat, Format> } {
+  return formatObject.format !== format;
+}
+
+const isUniformFormat = (format: string): format is OID4VCICredentialFormat => {
+  return ['jwt_vc_json', 'jwt_vc_json-ld', 'ldp_vc', 'vc+sd-jwt'].includes(format);
+};
+
+export function getUniformFormat(format: string | OID4VCICredentialFormat | CredentialFormat): OID4VCICredentialFormat {
+  // Already valid format
+  if (isUniformFormat(format)) {
+    return format;
+  }
+
+  // Older formats
+  if (format === 'jwt_vc' || format === 'jwt') {
+    return 'jwt_vc_json';
+  }
+  if (format === 'ldp_vc' || format === 'ldp') {
+    return 'ldp_vc';
+  }
+
+  throw new Error(`Invalid format: ${format}`);
+}
+
+export function getFormatForVersion(format: string, version: OpenId4VCIVersion) {
+  const uniformFormat = isUniformFormat(format) ? format : getUniformFormat(format);
+
+  if (version === OpenId4VCIVersion.VER_1_0_08) {
+    if (uniformFormat === 'jwt_vc_json') {
+      return 'jwt_vc' as const;
+    } else if (uniformFormat === 'ldp_vc' || uniformFormat === 'jwt_vc_json-ld') {
+      return 'ldp_vc' as const;
+    }
+  }
+
+  return uniformFormat;
+}

--- a/packages/common/lib/functions/index.ts
+++ b/packages/common/lib/functions/index.ts
@@ -2,3 +2,4 @@ export * from './CredentialRequestUtil';
 export * from './CredentialOfferUtil';
 export * from './Encoding';
 export * from './TypeConversionUtils';
+export * from './FormatUtils';

--- a/packages/common/lib/types/Authorization.types.ts
+++ b/packages/common/lib/types/Authorization.types.ts
@@ -1,5 +1,12 @@
 import { CredentialOfferPayload, UniformCredentialOffer } from './CredentialIssuance.types';
-import { ErrorResponse, IssuerCredentialDefinition, IssuerCredentialSubject, OID4VCICredentialFormat, PRE_AUTH_CODE_LITERAL } from './Generic.types';
+import {
+  ErrorResponse,
+  IssuerCredentialSubject,
+  JsonLdIssuerCredentialDefinition,
+  OID4VCICredentialFormat,
+  PRE_AUTH_CODE_LITERAL,
+  SdJwtVcCredentialDefinition,
+} from './Generic.types';
 import { EndpointMetadata } from './ServerMetadata';
 
 export interface CommonAuthorizationRequest {
@@ -64,9 +71,9 @@ export interface CommonAuthorizationRequest {
 /**
  * string type added for conformity with our previous code in the client
  */
-export type AuthorizationDetails = AuthorizationDetailsJwtVcJson | AuthorizationRequestJwtVcJsonLdAndLdpVc | string;
+export type AuthorizationDetails = AuthorizationDetailsJwtVcJson | AuthorizationDetailsJwtVcJsonLdAndLdpVc | AuthorizationDetailsSdJwtVc | string;
 
-export type AuthorizationRequest = AuthorizationRequestJwtVcJson | AuthorizationDetailsJwtVcJsonLdAndLdpVc;
+export type AuthorizationRequest = AuthorizationRequestJwtVcJson | AuthorizationRequestJwtVcJsonLdAndLdpVc | AuthorizationRequestSdJwtVc;
 
 export interface AuthorizationRequestJwtVcJson extends CommonAuthorizationRequest {
   authorization_details?: AuthorizationDetailsJwtVcJson[];
@@ -74,6 +81,10 @@ export interface AuthorizationRequestJwtVcJson extends CommonAuthorizationReques
 
 export interface AuthorizationRequestJwtVcJsonLdAndLdpVc extends CommonAuthorizationRequest {
   authorization_details?: AuthorizationDetailsJwtVcJsonLdAndLdpVc[];
+}
+
+export interface AuthorizationRequestSdJwtVc extends CommonAuthorizationRequest {
+  authorization_details?: AuthorizationDetailsSdJwtVc[];
 }
 
 export interface CommonAuthorizationDetails {
@@ -94,12 +105,14 @@ export interface CommonAuthorizationDetails {
    * the authorization detail's locations common data field MUST be set to the Credential Issuer Identifier value.
    */
   locations?: string[];
-  types: string[]; // This claim contains the type values the Wallet requests authorization for at the issuer.
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
 
 export interface AuthorizationDetailsJwtVcJson extends CommonAuthorizationDetails {
+  format: 'jwt_vc_json';
+
   /**
    * A JSON object containing a list of key value pairs, where the key identifies the claim offered in the Credential.
    * The value MAY be a dictionary, which allows to represent the full (potentially deeply nested) structure of the
@@ -107,9 +120,13 @@ export interface AuthorizationDetailsJwtVcJson extends CommonAuthorizationDetail
    * credential to be issued.
    */
   credentialSubject?: IssuerCredentialSubject;
+
+  types: string[]; // This claim contains the type values the Wallet requests authorization for at the issuer.
 }
 
 export interface AuthorizationDetailsJwtVcJsonLdAndLdpVc extends CommonAuthorizationDetails {
+  format: 'ldp_vc' | 'jwt_vc_json-ld';
+
   /**
    * REQUIRED. JSON object containing (and isolating) the detailed description of the credential type.
    * This object MUST be processed using full JSON-LD processing. It consists of the following sub-claims:
@@ -117,7 +134,13 @@ export interface AuthorizationDetailsJwtVcJsonLdAndLdpVc extends CommonAuthoriza
    *   - types: REQUIRED. JSON array as defined in Appendix E.1.3.2.
    *            This claim contains the type values the Wallet shall request in the subsequent Credential Request
    */
-  credential_definition: IssuerCredentialDefinition;
+  credential_definition: JsonLdIssuerCredentialDefinition;
+}
+
+export interface AuthorizationDetailsSdJwtVc extends CommonAuthorizationDetails {
+  format: 'vc+sd-jwt';
+
+  credential_definition: SdJwtVcCredentialDefinition;
 }
 
 export enum GrantTypes {

--- a/packages/common/lib/types/Generic.types.ts
+++ b/packages/common/lib/types/Generic.types.ts
@@ -15,7 +15,7 @@ export interface ImageInfo {
   [key: string]: unknown;
 }
 
-export type OID4VCICredentialFormat = 'jwt_vc_json' | 'jwt_vc_json-ld' | 'ldp_vc' /*| 'mso_mdoc'*/; // we do not support mdocs at this point
+export type OID4VCICredentialFormat = 'jwt_vc_json' | 'jwt_vc_json-ld' | 'ldp_vc' | 'vc+sd-jwt' /*| 'mso_mdoc'*/; // we do not support mdocs at this point
 
 export interface NameAndLocale {
   name?: string; // REQUIRED. String value of a display name for the Credential.
@@ -62,8 +62,6 @@ export interface CredentialIssuerMetadata extends CredentialIssuerMetadataOpts, 
 }
 
 export interface CredentialSupportedBrief {
-  name?: string; // fixme: Probably should not be here, is part of the display object
-  types: string[]; // REQUIRED. JSON array designating the types a certain credential type supports
   cryptographic_binding_methods_supported?: string[]; // OPTIONAL. Array of case sensitive strings that identify how the Credential is bound to the identifier of the End-User who possesses the Credential
   cryptographic_suites_supported?: string[]; // OPTIONAL. Array of case sensitive strings that identify the cryptographic suites that are supported for the cryptographic_binding_methods_supported
 }
@@ -75,24 +73,61 @@ export type CommonCredentialSupported = CredentialSupportedBrief & {
   /**
    * following properties are non-mso_mdoc specific and we might wanna rethink them when we're going to support mso_mdoc
    */
-  credentialSubject?: IssuerCredentialSubject; // OPTIONAL. A JSON object containing a list of key value pairs, where the key identifies the claim offered in the Credential. The value MAY be a dictionary, which allows to represent the full (potentially deeply nested) structure of the verifiable credential to be issued.
-  order?: string[]; //An array of claims.display.name values that lists them in the order they should be displayed by the Wallet.
 };
 
 export interface CredentialSupportedJwtVcJsonLdAndLdpVc extends CommonCredentialSupported {
+  types: string[]; // REQUIRED. JSON array designating the types a certain credential type supports
   '@context': ICredentialContextType[]; // REQUIRED. JSON array as defined in [VC_DATA], Section 4.1.
+  credentialSubject?: IssuerCredentialSubject; // OPTIONAL. A JSON object containing a list of key value pairs, where the key identifies the claim offered in the Credential. The value MAY be a dictionary, which allows to represent the full (potentially deeply nested) structure of the verifiable credential to be issued.
+  order?: string[]; //An array of claims.display.name values that lists them in the order they should be displayed by the Wallet.
+  format: 'ldp_vc' | 'jwt_vc_json-ld';
 }
 
 export interface CredentialSupportedJwtVcJson extends CommonCredentialSupported {
+  types: string[]; // REQUIRED. JSON array designating the types a certain credential type supports
+  credentialSubject?: IssuerCredentialSubject; // OPTIONAL. A JSON object containing a list of key value pairs, where the key identifies the claim offered in the Credential. The value MAY be a dictionary, which allows to represent the full (potentially deeply nested) structure of the verifiable credential to be issued.
+  order?: string[]; //An array of claims.display.name values that lists them in the order they should be displayed by the Wallet.
   format: 'jwt_vc_json';
 }
 
-export type CredentialSupported = CommonCredentialSupported & (CredentialSupportedJwtVcJson | CredentialSupportedJwtVcJsonLdAndLdpVc);
-
-export interface CredentialOfferFormat {
-  format: OID4VCICredentialFormat | string;
-  types: string[];
+export interface SdJwtVcCredentialDefinition {
+  vct: string; // REQUIRED. JSON string designating the type of an SD-JWT vc
+  claims?: IssuerCredentialSubject;
 }
+
+export interface CredentialSupportedSdJwtVc extends CommonCredentialSupported {
+  format: 'vc+sd-jwt';
+
+  // REQUIRED. JSON object containing the detailed description of the credential type
+  credential_definition: SdJwtVcCredentialDefinition;
+  order?: string[]; //An array of claims.display.name values that lists them in the order they should be displayed by the Wallet.
+}
+
+export type CredentialSupported = CommonCredentialSupported &
+  (CredentialSupportedJwtVcJson | CredentialSupportedJwtVcJsonLdAndLdpVc | CredentialSupportedSdJwtVc);
+
+export interface CommonCredentialOfferFormat {
+  format: OID4VCICredentialFormat | string;
+}
+
+export interface CredentialOfferFormatJwtVcJsonLdAndLdpVc extends CommonCredentialOfferFormat {
+  format: 'ldp_vc' | 'jwt_vc_json-ld';
+  // REQUIRED. JSON object containing (and isolating) the detailed description of the credential type. This object MUST be processed using full JSON-LD processing.
+  credential_definition: JsonLdIssuerCredentialDefinition;
+}
+
+export interface CredentialOfferFormatJwtVcJson extends CommonCredentialOfferFormat {
+  format: 'jwt_vc_json';
+  types: string[]; // REQUIRED. JSON array as defined in Appendix E.1.1.2. This claim contains the type values the Wallet shall request in the subsequent Credential Request.
+}
+
+export interface CredentialOfferFormatSdJwtVc extends CommonCredentialOfferFormat {
+  format: 'vc+sd-jwt';
+  credential_definition: SdJwtVcCredentialDefinition;
+}
+
+export type CredentialOfferFormat = CommonCredentialOfferFormat &
+  (CredentialOfferFormatJwtVcJsonLdAndLdpVc | CredentialOfferFormatJwtVcJson | CredentialOfferFormatSdJwtVc);
 
 /**
  * Optional storage that can help the credential Data Supplier. For instance to store credential input data during offer creation, if no additional data can be supplied later on
@@ -107,10 +142,10 @@ export type CreateCredentialOfferURIResult = {
   userPinRequired: boolean;
 };
 
-export interface IssuerCredentialDefinition {
+export interface JsonLdIssuerCredentialDefinition {
   '@context': ICredentialContextType[];
   types: string[];
-  credentialSubject: IssuerCredentialSubject;
+  credentialSubject?: IssuerCredentialSubject;
 }
 
 export interface ErrorResponse extends Response {
@@ -127,15 +162,20 @@ export interface CommonCredentialRequest {
   proof?: ProofOfPossession;
 }
 
-export interface CredentialRequestJwtVc extends CommonCredentialRequest {
-  format: 'jwt_vc_json' | 'jwt_vc_json-ld';
+export interface CredentialRequestJwtVcJson extends CommonCredentialRequest {
+  format: 'jwt_vc_json';
   types: string[];
   credentialSubject?: IssuerCredentialSubject;
 }
 
-export interface CredentialRequestLdpVc extends CommonCredentialRequest {
-  format: 'ldp_vc';
-  credential_definition: IssuerCredentialDefinition;
+export interface CredentialRequestJwtVcJsonLdAndLdpVc extends CommonCredentialRequest {
+  format: 'ldp_vc' | 'jwt_vc_json-ld';
+  credential_definition: JsonLdIssuerCredentialDefinition;
+}
+
+export interface CredentialRequestSdJwtVc extends CommonCredentialRequest {
+  format: 'vc+sd-jwt';
+  credential_definition: SdJwtVcCredentialDefinition;
 }
 
 export interface CommonCredentialResponse {
@@ -153,6 +193,11 @@ export interface CredentialResponseLdpVc extends CommonCredentialResponse {
 
 export interface CredentialResponseJwtVc {
   format: 'jwt_vc_json' | 'jwt_vc_json-ld';
+  credential: string;
+}
+
+export interface CredentialResponseSdJwtVc {
+  format: 'vc+sd-jwt';
   credential: string;
 }
 

--- a/packages/common/lib/types/v1_0_08.types.ts
+++ b/packages/common/lib/types/v1_0_08.types.ts
@@ -6,7 +6,7 @@ import { CredentialsSupportedDisplay, CredentialSupportedBrief, IssuerCredential
 export interface CredentialRequestV1_0_08 {
   type: string;
   format: CredentialFormat;
-  proof: ProofOfPossession;
+  proof?: ProofOfPossession;
 }
 
 export interface IssuerMetadataV1_0_08 {
@@ -34,11 +34,16 @@ export interface CredentialSupportedTypeV1_0_08 {
   [credentialType: string]: CredentialSupportedV1_0_08;
 }
 
+export interface CredentialSupportedFormatV1_0_08 extends CredentialSupportedBrief {
+  name?: string;
+  types: string[];
+}
+
 export interface CredentialSupportedV1_0_08 {
   display?: CredentialsSupportedDisplay[];
   formats: {
     // REQUIRED. A JSON object containing a list of key value pairs, where the key is a string identifying the format of the Credential. Below is a non-exhaustive list of valid key values defined by this specification:
-    [credentialFormat: string]: CredentialSupportedBrief;
+    [credentialFormat: string]: CredentialSupportedFormatV1_0_08;
   };
   claims?: IssuerCredentialSubject; // REQUIRED. A JSON object containing a list of key value pairs, where the key identifies the claim offered in the Credential. The value is a JSON object detailing the specifics about the support for the claim with a following non-exhaustive list of parameters that MAY be included:
 }

--- a/packages/common/lib/types/v1_0_11.types.ts
+++ b/packages/common/lib/types/v1_0_11.types.ts
@@ -3,10 +3,10 @@ import {
   CommonCredentialRequest,
   CredentialDataSupplierInput,
   CredentialOfferFormat,
-  CredentialRequestJwtVc,
-  CredentialRequestLdpVc,
+  CredentialRequestJwtVcJson,
+  CredentialRequestJwtVcJsonLdAndLdpVc,
+  CredentialRequestSdJwtVc,
   Grant,
-  IssuerCredentialDefinition,
 } from './Generic.types';
 
 export interface CredentialOfferV1_0_11 {
@@ -21,7 +21,7 @@ export interface CredentialOfferRESTRequest extends CredentialOfferV1_0_11 {
   credentialDataSupplierInput?: CredentialDataSupplierInput;
 }
 
-export interface CommonCredentialOfferPayloadV1_0_11 {
+export interface CredentialOfferPayloadV1_0_11 {
   /**
    * REQUIRED. The URL of the Credential Issuer, the Wallet is requested to obtain one or more Credentials from.
    */
@@ -48,22 +48,8 @@ export interface CommonCredentialOfferPayloadV1_0_11 {
   grants?: Grant;
 }
 
-export interface CredentialOfferLdpVcV1_0_11 extends CommonCredentialOfferPayloadV1_0_11 {
-  /**
-   * REQUIRED. JSON object containing (and isolating) the detailed description of the credential type.
-   * This object MUST be processed using full JSON-LD processing. It consists of the following sub-claims:
-   *   - @context: REQUIRED. JSON array as defined in Appendix E.1.3.2
-   *   - types: REQUIRED. JSON array as defined in Appendix E.1.3.2.
-   *            This claim contains the type values the Wallet shall request in the subsequent Credential Request
-   */
-  credential_definition: IssuerCredentialDefinition;
-}
-
-export type CredentialOfferJwtVcV1_0_11 = CommonCredentialOfferPayloadV1_0_11;
-
-export type CredentialOfferPayloadV1_0_11 = CommonCredentialOfferPayloadV1_0_11 & (CredentialOfferLdpVcV1_0_11 | CredentialOfferJwtVcV1_0_11);
-
-export type CredentialRequestV1_0_11 = CommonCredentialRequest & (CredentialRequestJwtVc | CredentialRequestLdpVc);
+export type CredentialRequestV1_0_11 = CommonCredentialRequest &
+  (CredentialRequestJwtVcJson | CredentialRequestJwtVcJsonLdAndLdpVc | CredentialRequestSdJwtVc);
 
 export interface AuthorizationRequestV1_0_11 extends AuthorizationDetailsJwtVcJson, AuthorizationDetailsJwtVcJson {
   issuer_state?: string;

--- a/packages/issuer-rest/lib/__tests__/IssuerTokenServer.spec.ts
+++ b/packages/issuer-rest/lib/__tests__/IssuerTokenServer.spec.ts
@@ -4,7 +4,6 @@ import {
   Alg,
   CNonceState,
   CredentialIssuerMetadataOpts,
-  CredentialOfferLdpVcV1_0_11,
   CredentialOfferSession,
   IssueStatus,
   Jwt,
@@ -45,18 +44,24 @@ describe('OID4VCIServer', () => {
       credentialOffer: {
         credential_offer: {
           credential_issuer: 'test_issuer',
-          credential_definition: {
-            '@context': ['test_context'],
-            types: ['VerifiableCredential'],
-            credentialSubject: {},
-          },
+          credentials: [
+            {
+              format: 'ldp_vc',
+              credential_definition: {
+                '@context': ['test_context'],
+                types: ['VerifiableCredential'],
+                credentialSubject: {},
+              },
+            },
+          ],
+
           grants: {
             'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
               user_pin_required: true,
               'pre-authorized_code': preAuthorizedCode1,
             },
           },
-        } as CredentialOfferLdpVcV1_0_11,
+        },
       },
     }
     const credentialOfferState2: CredentialOfferSession = {
@@ -75,7 +80,7 @@ describe('OID4VCIServer', () => {
               user_pin_required: false,
             },
           },
-        } as CredentialOfferLdpVcV1_0_11,
+        },
       },
     }
     const credentialOfferState3: CredentialOfferSession = { ...credentialOfferState1, preAuthorizedCode: preAuthorizedCode3, createdAt: 0 }
@@ -165,7 +170,7 @@ describe('OID4VCIServer', () => {
     expect(res.statusCode).toEqual(200)
     const actual = JSON.parse(res.text)
     expect(actual).toEqual({
-      access_token: expect.stringContaining('eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE2O'),
+      access_token: expect.stringContaining('eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOj'),
       token_type: 'bearer',
       expires_in: 300000,
       c_nonce: expect.any(String),

--- a/packages/issuer/lib/VcIssuer.ts
+++ b/packages/issuer/lib/VcIssuer.ts
@@ -19,9 +19,9 @@ import {
   Grant,
   IAT_ERROR,
   ISSUER_CONFIG_ERROR,
-  IssuerCredentialDefinition,
   IssueStatus,
   IStateManager,
+  JsonLdIssuerCredentialDefinition,
   JWT_VERIFY_CONFIG_ERROR,
   JWTVerifyCallback,
   JwtVerifyResult,
@@ -95,7 +95,7 @@ export class VcIssuer<DIDDoc extends object> {
   public async createCredentialOfferURI(opts: {
     grants?: Grant
     credentials?: (CredentialOfferFormat | string)[]
-    credentialDefinition?: IssuerCredentialDefinition
+    credentialDefinition?: JsonLdIssuerCredentialDefinition
     credentialOfferUri?: string
     credentialDataSupplierInput?: CredentialDataSupplierInput // Optional storage that can help the credential Data Supplier. For instance to store credential input data during offer creation, if no additional data can be supplied later on
     baseUri?: string

--- a/packages/issuer/lib/__tests__/VcIssuer.spec.ts
+++ b/packages/issuer/lib/__tests__/VcIssuer.spec.ts
@@ -1,7 +1,6 @@
 import { OpenID4VCIClient } from '@sphereon/oid4vci-client'
 import {
   Alg,
-  CredentialOfferLdpVcV1_0_11,
   CredentialOfferSession,
   CredentialSupported,
   IssuerCredentialSubjectDisplay,
@@ -58,11 +57,16 @@ describe('VcIssuer', () => {
       credentialOffer: {
         credential_offer: {
           credential_issuer: 'did:key:test',
-          credential_definition: {
-            types: ['VerifiableCredential'],
-            '@context': ['https://www.w3.org/2018/credentials/v1'],
-            credentialSubject: {},
-          },
+          credentials: [
+            {
+              format: 'ldp_vc',
+              credential_definition: {
+                types: ['VerifiableCredential'],
+                '@context': ['https://www.w3.org/2018/credentials/v1'],
+                credentialSubject: {},
+              },
+            },
+          ],
           grants: {
             authorization_code: { issuer_state: issuerState },
             'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
@@ -70,7 +74,7 @@ describe('VcIssuer', () => {
               user_pin_required: true,
             },
           },
-        } as CredentialOfferLdpVcV1_0_11,
+        },
       },
     })
     vcIssuer = new VcIssuerBuilder<DIDDocument>()

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig-base.json",
+  "extends": "./tsconfig-base.json",
   "files": [],
   "references": [
     {


### PR DESCRIPTION
Adds support for `vc+sd-jwt` format as described in https://github.com/vcstuff/oid4vc-haip-sd-jwt-vc

Because the format specific for `vc+sd-jwt` are a bit different than the other formats, it exposed some issues with the types currently being used. I updated all interfaces, made the uniform interfaces match draft 11 fully, and moved some v8/9 specific types outside of the uniform/generic types.

Because the types are different, and it exposed some issues with the current way requests are being made, there's more format speicfic logic now inline. I've didn't want to make this PR bigger than it currently is, so I've created a separate issue #76, to explore that work.

All tests are passing except the e2e test with mattr launchpad, as it's currently down for maintenance. In addition I had to change some tests with vendors, as the expected types do not match with the spec. They all hardcode that the version is draft 8, but then they use a format that is somewhere in between draft 8 and 9. Mabye that's what those vendors implemented, or maybe it was just a mock that was created? I don't know, but I've corrected them now.

I think if we also address #75 at the same time we address #76, it can clean up a lot of format specific code that's now spread across the repository