### PR TITLE
fix(sd-jwt): cnf instead of kid

### DIFF
--- a/packages/callback-example/package.json
+++ b/packages/callback-example/package.json
@@ -18,7 +18,7 @@
     "@sphereon/oid4vci-client": "workspace:*",
     "@sphereon/oid4vci-common": "workspace:*",
     "@sphereon/oid4vci-issuer": "workspace:*",
-    "@sphereon/ssi-types": "0.17.6-unstable.69",
+    "@sphereon/ssi-types": "^0.18.0",
     "jose": "^4.10.0"
   },
   "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@sphereon/oid4vci-common": "workspace:*",
-    "@sphereon/ssi-types": "0.17.6-unstable.69",
+    "@sphereon/ssi-types": "^0.18.0",
     "cross-fetch": "^3.1.8",
     "debug": "^4.3.4"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -10,7 +10,7 @@
     "build:clean": "tsc --build --clean && tsc --build"
   },
   "dependencies": {
-    "@sphereon/ssi-types": "0.17.6-unstable.69",
+    "@sphereon/ssi-types": "^0.18.0",
     "cross-fetch": "^3.1.8",
     "jwt-decode": "^3.1.2"
   },

--- a/packages/issuer-rest/package.json
+++ b/packages/issuer-rest/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "@sphereon/oid4vci-common": "workspace:*",
     "@sphereon/oid4vci-issuer": "workspace:*",
-    "@sphereon/ssi-express-support": "0.17.6-unstable.69",
-    "@sphereon/ssi-types": "0.17.6-unstable.69",
+    "@sphereon/ssi-express-support": "^0.18.0",
+    "@sphereon/ssi-types": "^0.18.0",
     "body-parser": "^1.20.2",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",

--- a/packages/issuer/lib/VcIssuer.ts
+++ b/packages/issuer/lib/VcIssuer.ts
@@ -255,6 +255,8 @@ export class VcIssuer<DIDDoc extends object> {
 
       const { preAuthSession, authSession, cNonceState, jwtVerifyResult } = validated
       const did = jwtVerifyResult.did
+      const jwk = jwtVerifyResult.jwk
+      const kid = jwtVerifyResult.kid
       const newcNonce = opts.newCNonce ? opts.newCNonce : v4()
       const newcNonceState = {
         cNonce: newcNonce,
@@ -305,19 +307,30 @@ export class VcIssuer<DIDDoc extends object> {
       if (!credential) {
         throw Error('A credential needs to be supplied at this point')
       }
-      if (did) {
-        if (CredentialMapper.isSdJwtDecodedCredentialPayload(credential)) {
-          credential.sub = did
-        } else {
-          const credentialSubjects = Array.isArray(credential.credentialSubject) ? credential.credentialSubject : [credential.credentialSubject]
-          credentialSubjects.map((subject) => {
-            if (!subject.id) {
-              subject.id = did
-            }
-            return subject
-          })
-          credential.credentialSubject = Array.isArray(credential.credentialSubject) ? credentialSubjects : credentialSubjects[0]
+      // Bind credential to the provided proof of possession
+      if (CredentialMapper.isSdJwtDecodedCredentialPayload(credential) && (kid || jwk) && !credential.cnf) {
+        if (kid) {
+          // NOTE: any can be removed once this PR is released:
+          // https://github.com/Sphereon-Opensource/SSI-SDK/pull/150
+          credential.cnf = {
+            kid,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any
+        } else if (jwk) {
+          credential.cnf = {
+            jwk,
+          }
         }
+      }
+      if (did && !CredentialMapper.isSdJwtDecodedCredentialPayload(credential)) {
+        const credentialSubjects = Array.isArray(credential.credentialSubject) ? credential.credentialSubject : [credential.credentialSubject]
+        credentialSubjects.map((subject) => {
+          if (!subject.id) {
+            subject.id = did
+          }
+          return subject
+        })
+        credential.credentialSubject = Array.isArray(credential.credentialSubject) ? credentialSubjects : credentialSubjects[0]
       }
 
       const verifiableCredential = await this.issueCredentialImpl(

--- a/packages/issuer/lib/VcIssuer.ts
+++ b/packages/issuer/lib/VcIssuer.ts
@@ -312,6 +312,7 @@ export class VcIssuer<DIDDoc extends object> {
         if (kid) {
           credential.cnf = {
             kid
+          }
         } else if (jwk) {
           credential.cnf = {
             jwk,

--- a/packages/issuer/lib/VcIssuer.ts
+++ b/packages/issuer/lib/VcIssuer.ts
@@ -310,8 +310,6 @@ export class VcIssuer<DIDDoc extends object> {
       // Bind credential to the provided proof of possession
       if (CredentialMapper.isSdJwtDecodedCredentialPayload(credential) && (kid || jwk) && !credential.cnf) {
         if (kid) {
-          // NOTE: any can be removed once this PR is released:
-          // https://github.com/Sphereon-Opensource/SSI-SDK/pull/150
           credential.cnf = {
             kid,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/issuer/lib/VcIssuer.ts
+++ b/packages/issuer/lib/VcIssuer.ts
@@ -311,9 +311,7 @@ export class VcIssuer<DIDDoc extends object> {
       if (CredentialMapper.isSdJwtDecodedCredentialPayload(credential) && (kid || jwk) && !credential.cnf) {
         if (kid) {
           credential.cnf = {
-            kid,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          } as any
+            kid
         } else if (jwk) {
           credential.cnf = {
             jwk,

--- a/packages/issuer/package.json
+++ b/packages/issuer/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@sphereon/oid4vci-common": "workspace:*",
-    "@sphereon/ssi-types": "0.17.6-unstable.69",
+    "@sphereon/ssi-types": "^0.18.0",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: workspace:*
         version: link:../issuer
       '@sphereon/ssi-types':
-        specifier: 0.17.6-unstable.69
-        version: 0.17.6-unstable.69
+        specifier: ^0.18.0
+        version: 0.18.0
       jose:
         specifier: ^4.10.0
         version: 4.14.6
@@ -118,8 +118,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       '@sphereon/ssi-types':
-        specifier: 0.17.6-unstable.69
-        version: 0.17.6-unstable.69
+        specifier: ^0.18.0
+        version: 0.18.0
       cross-fetch:
         specifier: ^3.1.8
         version: 3.1.8
@@ -206,8 +206,8 @@ importers:
   packages/common:
     dependencies:
       '@sphereon/ssi-types':
-        specifier: 0.17.6-unstable.69
-        version: 0.17.6-unstable.69
+        specifier: ^0.18.0
+        version: 0.18.0
       cross-fetch:
         specifier: ^3.1.8
         version: 3.1.8
@@ -228,8 +228,8 @@ importers:
         specifier: workspace:*
         version: link:../common
       '@sphereon/ssi-types':
-        specifier: 0.17.6-unstable.69
-        version: 0.17.6-unstable.69
+        specifier: ^0.18.0
+        version: 0.18.0
       awesome-qr:
         specifier: ^2.1.5-rc.0
         version: 2.1.5-rc.0
@@ -262,11 +262,11 @@ importers:
         specifier: workspace:*
         version: link:../issuer
       '@sphereon/ssi-express-support':
-        specifier: 0.17.6-unstable.69
-        version: 0.17.6-unstable.69
+        specifier: ^0.18.0
+        version: 0.18.0
       '@sphereon/ssi-types':
-        specifier: 0.17.6-unstable.69
-        version: 0.17.6-unstable.69
+        specifier: ^0.18.0
+        version: 0.18.0
       body-parser:
         specifier: ^1.20.2
         version: 1.20.2
@@ -3491,8 +3491,8 @@ packages:
       webcrypto-shim: 0.1.7
     dev: true
 
-  /@sphereon/ssi-express-support@0.17.6-unstable.69:
-    resolution: {integrity: sha512-IpiiW6KPv5zjvlCCxyw4S093WL4na6zvJjoWI26te04Y4T1yYF3FfaGdcA+BAQl4URvvcp09mzay2Z8RwmDLSA==}
+  /@sphereon/ssi-express-support@0.18.0:
+    resolution: {integrity: sha512-qrZkCdDwmu+wsc8ZGvcbSZ89vPCoXLEqHpBYbOuKlC5Dcl9qLiAU8SpC5I5tqCbfFE2mC7lw2ybtl0GYZRXbsQ==}
     peerDependencies:
       '@noble/hashes': 1.2.0
       passport-azure-ad: ^4.3.5
@@ -3548,8 +3548,8 @@ packages:
       - supports-color
     dev: true
 
-  /@sphereon/ssi-types@0.17.6-unstable.69:
-    resolution: {integrity: sha512-VwjVd6XhoV5QecWcRh0RpBf5N324tfhYcQrVk9se3brqMNMauZTBbhUhk+QLdwFd+u/1+IfEWnS28HyIU7lXHQ==}
+  /@sphereon/ssi-types@0.18.0:
+    resolution: {integrity: sha512-D2n42NAhHCwpL4K7BqQXO9dYQ8n3st/1eJQrLqokJ18B9r2gury3km4cp+ZdiIxfefUaP9RBCeuWaiRUvjZ94w==}
     dependencies:
       '@sd-jwt/core': 0.1.2-alpha.0
       jwt-decode: 3.1.2


### PR DESCRIPTION
small fix to use `cnf` object instead of `sub` property for binding the sd-jwt as defined in the sd-jwt vc spec.

Also adds support for `kid` (did) binding in addition to jwk binding for an sd-jwt

