### PR TITLE
fix: add sd-jwt to issuer callback

### DIFF
--- a/packages/callback-example/lib/IssuerCallback.ts
+++ b/packages/callback-example/lib/IssuerCallback.ts
@@ -5,7 +5,7 @@ import { securityLoader } from '@digitalcredentials/security-document-loader'
 import vc from '@digitalcredentials/vc'
 import { CredentialRequestV1_0_11 } from '@sphereon/oid4vci-common'
 import { CredentialIssuanceInput } from '@sphereon/oid4vci-issuer'
-import { W3CVerifiableCredential } from '@sphereon/ssi-types'
+import { CompactSdJwtVc, W3CVerifiableCredential } from '@sphereon/ssi-types'
 
 // Example on how to generate a did:key to issue a verifiable credential
 export const generateDid = async () => {
@@ -20,7 +20,10 @@ export const getIssuerCallback = (credential: CredentialIssuanceInput, keyPair: 
     throw new Error('A credential needs to be provided')
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  return async (_opts: { credentialRequest?: CredentialRequestV1_0_11; credential?: CredentialIssuanceInput }): Promise<W3CVerifiableCredential> => {
+  return async (_opts: {
+    credentialRequest?: CredentialRequestV1_0_11
+    credential?: CredentialIssuanceInput
+  }): Promise<W3CVerifiableCredential | CompactSdJwtVc> => {
     const documentLoader = securityLoader().build()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const verificationKey: any = Array.from(keyPair.values())[0]

--- a/packages/issuer/lib/VcIssuer.ts
+++ b/packages/issuer/lib/VcIssuer.ts
@@ -35,7 +35,7 @@ import {
   UniformCredentialRequest,
   URIState,
 } from '@sphereon/oid4vci-common'
-import { CredentialMapper, W3CVerifiableCredential } from '@sphereon/ssi-types'
+import { CompactSdJwtVc, CredentialMapper, W3CVerifiableCredential } from '@sphereon/ssi-types'
 import { v4 } from 'uuid'
 
 import { assertValidPinNumber, createCredentialOfferObject, createCredentialOfferURIFromObject } from './functions'
@@ -558,7 +558,7 @@ export class VcIssuer<DIDDoc extends object> {
       format?: OID4VCICredentialFormat
     },
     issuerCallback?: CredentialSignerCallback<DIDDoc>,
-  ): Promise<W3CVerifiableCredential> {
+  ): Promise<W3CVerifiableCredential | CompactSdJwtVc> {
     if ((!opts.credential && !opts.credentialRequest) || !this._credentialSignerCallback) {
       throw new Error(ISSUER_CONFIG_ERROR)
     }

--- a/packages/issuer/lib/types/index.ts
+++ b/packages/issuer/lib/types/index.ts
@@ -7,7 +7,13 @@ import {
   OID4VCICredentialFormat,
   UniformCredentialRequest,
 } from '@sphereon/oid4vci-common'
-import { ICredential, SdJwtDecodedVerifiableCredentialPayload, SdJwtDisclosureFrame, W3CVerifiableCredential } from '@sphereon/ssi-types'
+import {
+  CompactSdJwtVc,
+  ICredential,
+  SdJwtDecodedVerifiableCredentialPayload,
+  SdJwtDisclosureFrame,
+  W3CVerifiableCredential,
+} from '@sphereon/ssi-types'
 
 export type CredentialSignerCallback<T extends object> = (opts: {
   credentialRequest: UniformCredentialRequest
@@ -18,7 +24,7 @@ export type CredentialSignerCallback<T extends object> = (opts: {
    * An implementation that wants to look into the DIDDoc would have to do a cast in the signer callback implementation
    */
   jwtVerifyResult: JwtVerifyResult<T>
-}) => Promise<W3CVerifiableCredential>
+}) => Promise<W3CVerifiableCredential | CompactSdJwtVc>
 
 export interface CredentialDataSupplierArgs extends CNonceState {
   credentialRequest: UniformCredentialRequest


### PR DESCRIPTION
Adds `CompactSdJwtVc` to the return type of the signer callback.

It doesn't really impact things as you could already return `CompactJwt` (a string) and `CompactSdJwtVc` is also a string, but it's good when looking at the implemetnation for reference to see that SD-JWT is also supported