### PR TITLE
fix: disable awesome-qr in rn

### DIFF
--- a/packages/issuer/package.json
+++ b/packages/issuer/package.json
@@ -22,6 +22,9 @@
       "optional": true
     }
   },
+  "react-native": {
+    "awesome-qr": false
+  },
   "devDependencies": {
     "@sphereon/oid4vci-client": "workspace:*",
     "@types/jest": "^29.5.3",


### PR DESCRIPTION
We have a combined `@credo-ts/openid4vc` package that depends on the common, issuer and client libraires.

When importing this into react native it is giving us some issues because RN resolves conditional imports to bundle in the JS bundle and awesome-qr is an optional dependnecy.

We could add awesome-qr as a dependency and it'd then bundle awesome-qr with our app, but adding a `react-native` clause to the issuer package also solves the issue

It will limit the usage of creating a QR when creating an offer, but then someone will need to a) write an issuer in React Native and b) use the QR generation options. And even then is the question whether this package works in React Native.

It seemed like a valid workaround. But i can also just add the dependency to the bundle if you think we shouldn't do this