### PR TITLE
fix: type for cred request ldp

### DIFF
--- a/packages/common/lib/functions/CredentialRequestUtil.ts
+++ b/packages/common/lib/functions/CredentialRequestUtil.ts
@@ -7,14 +7,12 @@ export function getTypesFromRequest(credentialRequest: UniformCredentialRequest,
   if (credentialRequest.format === 'jwt_vc_json' || credentialRequest.format === 'jwt_vc') {
     types = credentialRequest.types;
   } else if (credentialRequest.format === 'jwt_vc_json-ld' || credentialRequest.format === 'ldp_vc') {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     types =
       'credential_definition' in credentialRequest && credentialRequest.credential_definition
-        ? // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        ? credentialRequest.credential_definition.types
+        : // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
-          credentialRequest.credential_definition.types
-        : credentialRequest.types;
+          credentialRequest.types;
   } else if (credentialRequest.format === 'vc+sd-jwt') {
     types = [credentialRequest.vct];
   }

--- a/packages/common/lib/types/v1_0_11.types.ts
+++ b/packages/common/lib/types/v1_0_11.types.ts
@@ -5,9 +5,9 @@ import {
   CredentialIssuerMetadataOpts,
   CredentialOfferFormat,
   CredentialRequestJwtVcJson,
+  CredentialRequestJwtVcJsonLdAndLdpVc,
   CredentialRequestSdJwtVc,
   Grant,
-  JsonLdIssuerCredentialDefinition,
 } from './Generic.types';
 import { QRCodeOpts } from './QRCode.types';
 import { AuthorizationServerMetadata } from './ServerMetadata';
@@ -58,13 +58,8 @@ export interface CredentialOfferPayloadV1_0_11 {
 }
 
 export type CredentialRequestV1_0_11 = CommonCredentialRequest &
-  (CredentialRequestJwtVcJson | CredentialRequestJwtVcJsonLdAndLdpVcV1_0_11 | CredentialRequestSdJwtVc);
+  (CredentialRequestJwtVcJson | CredentialRequestJwtVcJsonLdAndLdpVc | CredentialRequestSdJwtVc);
 
-export interface CredentialRequestJwtVcJsonLdAndLdpVcV1_0_11
-  extends CommonCredentialRequest,
-    Pick<JsonLdIssuerCredentialDefinition, 'credentialSubject' | 'types'> {
-  format: 'ldp_vc' | 'jwt_vc_json-ld';
-}
 export interface CredentialIssuerMetadataV1_0_11 extends CredentialIssuerMetadataOpts, Partial<AuthorizationServerMetadata> {
   credential_endpoint: string; // REQUIRED. URL of the Credential Issuer's Credential Endpoint. This URL MUST use the https scheme and MAY contain port, path and query parameter components.
   authorization_server?: string;


### PR DESCRIPTION
The type was incorrectly set, as according to draft 11 of OID4VCI the LDP credential request MUST have a `credential_definition` object.

The same is true for draft 12.

The code still works with top-level types as well, (as currently both `credential_definition.types` and `types` already worked), but the type is corrected now.