### PR TITLE
fix: await session state updates

### DIFF
--- a/packages/callback-example/lib/__tests__/issuerCallback.spec.ts
+++ b/packages/callback-example/lib/__tests__/issuerCallback.spec.ts
@@ -139,7 +139,7 @@ describe('issuerCallback', () => {
     })
 
     const nonces = new MemoryStates<CNonceState>()
-    nonces.set('test_value', { cNonce: 'test_value', createdAt: +new Date(), issuerState: 'existing-state' })
+    await nonces.set('test_value', { cNonce: 'test_value', createdAt: +new Date(), issuerState: 'existing-state' })
     vcIssuer = new VcIssuerBuilder<DIDDocument>()
       .withAuthorizationServer('https://authorization-server')
       .withCredentialEndpoint('https://credential-endpoint')

--- a/packages/issuer/lib/VcIssuer.ts
+++ b/packages/issuer/lib/VcIssuer.ts
@@ -32,19 +32,14 @@ import {
   toUniformCredentialOfferRequest,
   TYP_ERROR,
   UniformCredentialRequest,
-  URIState
+  URIState,
 } from '@sphereon/oid4vci-common'
 import { CompactSdJwtVc, CredentialMapper, W3CVerifiableCredential } from '@sphereon/ssi-types'
 import { v4 } from 'uuid'
 
 import { assertValidPinNumber, createCredentialOfferObject, createCredentialOfferURIFromObject } from './functions'
 import { LookupStateManager } from './state-manager'
-import {
-  CredentialDataSupplier,
-  CredentialDataSupplierArgs,
-  CredentialIssuanceInput,
-  CredentialSignerCallback
-} from './types'
+import { CredentialDataSupplier, CredentialDataSupplierArgs, CredentialIssuanceInput, CredentialSignerCallback } from './types'
 
 const SECOND = 1000
 
@@ -350,17 +345,17 @@ export class VcIssuer<DIDDoc extends object> {
         throw new Error(CREDENTIAL_MISSING_ERROR)
       }
       // remove the previous nonce
-      this.cNonces.delete(cNonceState.cNonce)
+      await this.cNonces.delete(cNonceState.cNonce)
 
       if (preAuthorizedCode && preAuthSession) {
         preAuthSession.lastUpdatedAt = +new Date()
         preAuthSession.status = IssueStatus.CREDENTIAL_ISSUED
-        this._credentialOfferSessions.set(preAuthorizedCode, preAuthSession)
+        await this._credentialOfferSessions.set(preAuthorizedCode, preAuthSession)
       } else if (issuerState && authSession) {
         // If both were set we used the pre auth flow above as well, hence the else if
         authSession.lastUpdatedAt = +new Date()
         authSession.status = IssueStatus.CREDENTIAL_ISSUED
-        this._credentialOfferSessions.set(issuerState, authSession)
+        await this._credentialOfferSessions.set(issuerState, authSession)
       }
 
       return {
@@ -390,7 +385,7 @@ export class VcIssuer<DIDDoc extends object> {
         preAuthSession.lastUpdatedAt = +new Date()
         preAuthSession.status = IssueStatus.ERROR
         preAuthSession.error = error instanceof Error ? error.message : error?.toString()
-        this._credentialOfferSessions.set(preAuthorizedCode, preAuthSession)
+        await this._credentialOfferSessions.set(preAuthorizedCode, preAuthSession)
       }
     }
     if (issuerState) {
@@ -399,7 +394,7 @@ export class VcIssuer<DIDDoc extends object> {
         authSession.lastUpdatedAt = +new Date()
         authSession.status = IssueStatus.ERROR
         authSession.error = error instanceof Error ? error.message : error?.toString()
-        this._credentialOfferSessions.set(issuerState, authSession)
+        await this._credentialOfferSessions.set(issuerState, authSession)
       }
     }
   }

--- a/packages/issuer/lib/state-manager/LookupStateManager.ts
+++ b/packages/issuer/lib/state-manager/LookupStateManager.ts
@@ -48,8 +48,8 @@ export class LookupStateManager<K extends StateType, V extends StateType> implem
   }
 
   async delete(id: string): Promise<boolean> {
-    return await this.assertedValueId(id).then((value) => {
-      this.keyValueMapper.delete(id)
+    return await this.assertedValueId(id).then(async (value) => {
+      await this.keyValueMapper.delete(id)
       return this.valueStateManager.delete(value)
     })
   }
@@ -68,8 +68,8 @@ export class LookupStateManager<K extends StateType, V extends StateType> implem
   }
 
   async setMapped(id: string, keyValue: K, stateValue: V): Promise<void> {
-    this.keyValueMapper.set(id, keyValue)
-    this.valueStateManager.set(id, stateValue)
+    await this.keyValueMapper.set(id, keyValue)
+    await this.valueStateManager.set(id, stateValue)
   }
 
   async getAsserted(id: string): Promise<V> {

--- a/packages/issuer/lib/tokens/index.ts
+++ b/packages/issuer/lib/tokens/index.ts
@@ -88,7 +88,7 @@ export const assertValidAccessTokenRequest = async (
   const credentialOfferSession = await credentialOfferSessions.getAsserted(request[PRE_AUTH_CODE_LITERAL])
   credentialOfferSession.status = IssueStatus.ACCESS_TOKEN_REQUESTED
   credentialOfferSession.lastUpdatedAt = +new Date()
-  credentialOfferSessions.set(request[PRE_AUTH_CODE_LITERAL], credentialOfferSession)
+  await credentialOfferSessions.set(request[PRE_AUTH_CODE_LITERAL], credentialOfferSession)
   if (!isValidGrant(credentialOfferSession, request.grant_type)) {
     throw new TokenError(400, TokenErrorResponse.invalid_grant, UNSUPPORTED_GRANT_TYPE_ERROR)
   }
@@ -165,6 +165,6 @@ export const createAccessTokenResponse = async (
   const credentialOfferSession = await credentialOfferSessions.getAsserted(preAuthorizedCode)
   credentialOfferSession.status = IssueStatus.ACCESS_TOKEN_CREATED
   credentialOfferSession.lastUpdatedAt = +new Date()
-  credentialOfferSessions.set(preAuthorizedCode, credentialOfferSession)
+  await credentialOfferSessions.set(preAuthorizedCode, credentialOfferSession)
   return response
 }


### PR DESCRIPTION
Some state updates (set, delete) were not awaited. When updating the in memory session manager to one that uses persistance storage we were running into issues were we would close our database session (as the call to this library is finished), but then a write would still happen as the updates to the session were not awaited.

Were these awaits left out on purpose? 