### PR TITLE
fix: use seconds for all expires in values

### DIFF
--- a/packages/callback-example/lib/__tests__/issuerCallback.spec.ts
+++ b/packages/callback-example/lib/__tests__/issuerCallback.spec.ts
@@ -267,7 +267,7 @@ describe('issuerCallback', () => {
 
     expect(credentialResponse).toEqual({
       c_nonce: expect.any(String),
-      c_nonce_expires_in: 300000,
+      c_nonce_expires_in: 300,
       credential: {
         '@context': ['https://www.w3.org/2018/credentials/v1', 'https://w3id.org/security/suites/ed25519-2020/v1'],
         credentialSubject: {

--- a/packages/client/lib/__tests__/SdJwt.spec.ts
+++ b/packages/client/lib/__tests__/SdJwt.spec.ts
@@ -153,7 +153,7 @@ describe('sd-jwt vc', () => {
 
       expect(credentials).toEqual({
         c_nonce: 'new-c-nonce',
-        c_nonce_expires_in: 300000,
+        c_nonce_expires_in: 300,
         credential: 'sd-jwt',
         format: 'vc+sd-jwt',
       });

--- a/packages/issuer-rest/lib/__tests__/ClientIssuerIT.spec.ts
+++ b/packages/issuer-rest/lib/__tests__/ClientIssuerIT.spec.ts
@@ -327,7 +327,7 @@ describe('VcIssuer', () => {
       proofCallbacks: { signCallback: proofOfPossessionCallbackFunction },
     })
     expect(credentialResponse).toMatchObject({
-      c_nonce_expires_in: 300000,
+      c_nonce_expires_in: 300,
       credential: {
         '@context': ['https://www.w3.org/2018/credentials/v1'],
         credentialSubject: {},

--- a/packages/issuer-rest/lib/__tests__/IssuerTokenServer.spec.ts
+++ b/packages/issuer-rest/lib/__tests__/IssuerTokenServer.spec.ts
@@ -148,7 +148,7 @@ describe('OID4VCIServer', () => {
           accessTokenSignerCallback: signerCallback,
           accessTokenIssuer: 'https://www.example.com',
           preAuthorizedCodeExpirationDuration: 2000,
-          tokenExpiresIn: 300000,
+          tokenExpiresIn: 300,
         },
       },
     })
@@ -172,11 +172,11 @@ describe('OID4VCIServer', () => {
     expect(actual).toEqual({
       access_token: expect.stringContaining('eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQi'),
       token_type: 'bearer',
-      expires_in: 300000,
+      expires_in: 300,
       c_nonce: expect.any(String),
-      c_nonce_expires_in: 300000,
+      c_nonce_expires_in: 300,
       authorization_pending: false,
-      interval: 300000,
+      interval: 300,
     })
   })
   it('should return http code 400 with message User pin is required', async () => {

--- a/packages/issuer-rest/lib/oid4vci-api-functions.ts
+++ b/packages/issuer-rest/lib/oid4vci-api-functions.ts
@@ -79,8 +79,8 @@ export function accessTokenEndpoint<DIDDoc extends object>(
   const accessTokenIssuer = opts?.accessTokenIssuer ?? process.env.ACCESS_TOKEN_ISSUER ?? issuer.issuerMetadata.credential_issuer
 
   const preAuthorizedCodeExpirationDuration =
-    opts?.preAuthorizedCodeExpirationDuration ?? getNumberOrUndefined(process.env.PRE_AUTHORIZED_CODE_EXPIRATION_DURATION) ?? 300000
-  const interval = opts?.interval ?? getNumberOrUndefined(process.env.INTERVAL) ?? 300000
+    opts?.preAuthorizedCodeExpirationDuration ?? getNumberOrUndefined(process.env.PRE_AUTHORIZED_CODE_EXPIRATION_DURATION) ?? 300
+  const interval = opts?.interval ?? getNumberOrUndefined(process.env.INTERVAL) ?? 300
   const tokenExpiresIn = opts?.tokenExpiresIn ?? 300
 
   // todo: this means we cannot sign JWTs or issue access tokens when configured from env vars!

--- a/packages/issuer/lib/VcIssuer.ts
+++ b/packages/issuer/lib/VcIssuer.ts
@@ -41,8 +41,6 @@ import { assertValidPinNumber, createCredentialOfferObject, createCredentialOffe
 import { LookupStateManager } from './state-manager'
 import { CredentialDataSupplier, CredentialDataSupplierArgs, CredentialIssuanceInput, CredentialSignerCallback } from './types'
 
-const SECOND = 1000
-
 export class VcIssuer<DIDDoc extends object> {
   private readonly _issuerMetadata: CredentialIssuerMetadataOpts
   private readonly _userPinRequired: boolean
@@ -79,8 +77,7 @@ export class VcIssuer<DIDDoc extends object> {
     this._credentialSignerCallback = args?.credentialSignerCallback
     this._jwtVerifyCallback = args?.jwtVerifyCallback
     this._credentialDataSupplier = args?.credentialDataSupplier
-    this._cNonceExpiresIn =
-      ((args?.cNonceExpiresIn ?? (process.env.C_NONCE_EXPIRES_IN ? parseInt(process.env.C_NONCE_EXPIRES_IN) : 300)) as number) * SECOND
+    this._cNonceExpiresIn = (args?.cNonceExpiresIn ?? (process.env.C_NONCE_EXPIRES_IN ? parseInt(process.env.C_NONCE_EXPIRES_IN) : 300)) as number
   }
 
   public getCredentialOfferSessionById(id: string): Promise<CredentialOfferSession> {
@@ -247,7 +244,7 @@ export class VcIssuer<DIDDoc extends object> {
       }
       const validated = await this.validateCredentialRequestProof({
         ...opts,
-        tokenExpiresIn: opts.tokenExpiresIn ?? 180000,
+        tokenExpiresIn: opts.tokenExpiresIn ?? 180,
       })
       preAuthorizedCode = validated.preAuthorizedCode
       issuerState = validated.issuerState

--- a/packages/issuer/lib/__tests__/VcIssuer.spec.ts
+++ b/packages/issuer/lib/__tests__/VcIssuer.spec.ts
@@ -362,7 +362,7 @@ describe('VcIssuer', () => {
       }),
     ).resolves.toEqual({
       c_nonce: 'new-test-nonce',
-      c_nonce_expires_in: 300000,
+      c_nonce_expires_in: 300,
       credential: {
         '@context': ['https://www.w3.org/2018/credentials/v1'],
         credentialSubject: {},

--- a/packages/issuer/lib/tokens/index.ts
+++ b/packages/issuer/lib/tokens/index.ts
@@ -43,7 +43,8 @@ export const generateAccessToken = async (
   },
 ): Promise<string> => {
   const { accessTokenIssuer, alg, accessTokenSignerCallback, tokenExpiresIn, preAuthorizedCode } = opts
-  const iat = new Date().getTime()
+  // JWT uses seconds for iat and exp
+  const iat = new Date().getTime() / 1000
   const exp = iat + tokenExpiresIn
   const jwt: Jwt = {
     header: { typ: 'JWT', alg: alg ?? Alg.ES256K },


### PR DESCRIPTION
Seems there were some other places were milliseconds were used, but the specs describe to use seconds for `iat`, `exp`, `c_nonce_expires_in`, `interval` and `expires_in`

I modified some defaults, so this is technically a breaking change, but I think the current implementation is incorrect so it could also be seen as a fix I think.