### PR TITLE
feature/SPRIND-14_based_on-draft13

### DIFF
--- a/packages/callback-example/lib/__tests__/issuerCallback.spec.ts
+++ b/packages/callback-example/lib/__tests__/issuerCallback.spec.ts
@@ -216,6 +216,32 @@ describe('issuerCallback', () => {
     )
   })
 
+  it('should add a proof to a credential without did', async () => {
+    const credential: ICredential = {
+      '@context': ['https://www.w3.org/2018/credentials/v1'],
+      type: ['VerifiableCredential'],
+      issuer: IDENTIPROOF_ISSUER_URL,
+      credentialSubject: {},
+      issuanceDate: new Date().toISOString(),
+    }
+    const vc = await getIssuerCallbackV1_0_11(credential, didKey.keyPairs, didKey.didDocument.verificationMethod[0].id)({})
+    console.log('vc:', vc)
+    expect(vc).toEqual({
+      '@context': ['https://www.w3.org/2018/credentials/v1', 'https://w3id.org/security/suites/ed25519-2020/v1'],
+      credentialSubject: {},
+      issuanceDate: expect.any(String),
+      issuer: expect.stringContaining('example.com'),
+      proof: {
+        created: expect.any(String),
+        proofPurpose: 'assertionMethod',
+        proofValue: expect.any(String),
+        type: 'Ed25519Signature2020',
+        verificationMethod: expect.any(String),
+      },
+      type: ['VerifiableCredential'],
+    })
+  })
+
   it('Should pass requesting a verifiable credential using the client', async () => {
     const credReqClient = (await CredentialRequestClientBuilder.fromURI({ uri: INITIATION_TEST_URI }))
       .withCredentialEndpoint('https://oidc4vci.demo.spruceid.com/credential')

--- a/packages/client/lib/__tests__/CredentialRequestClient.spec.ts
+++ b/packages/client/lib/__tests__/CredentialRequestClient.spec.ts
@@ -31,7 +31,6 @@ import { getMockData } from './data/VciDataFixtures';
 const partialJWT = 'eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmN';
 const partialJWT_withoutDid = 'eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJlYmZlYjFmNzEyZWJjNmYxYzI3N';
 
-
 const jwt1_0_08: Jwt = {
   header: { alg: Alg.ES256, kid: 'did:example:ebfeb1f712ebc6f1c276e12ec21/keys/1', typ: 'jwt' },
   payload: { iss: 'sphereon:wallet', nonce: 'tZignsnFbp', jti: 'tZignsnFbp223', aud: IDENTIPROOF_ISSUER_URL },
@@ -133,16 +132,16 @@ describe('Credential Request Client ', () => {
     const mockedVC =
       'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sImlkIjoiaHR0cDovL2V4YW1wbGUuZWR1L2NyZWRlbnRpYWxzLzM3MzIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiVW5pdmVyc2l0eURlZ3JlZUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiaHR0cHM6Ly9leGFtcGxlLmVkdS9pc3N1ZXJzLzU2NTA0OSIsImlzc3VhbmNlRGF0ZSI6IjIwMTAtMDEtMDFUMDA6MDA6MDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJlYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMifX19LCJpc3MiOiJodHRwczovL2V4YW1wbGUuZWR1L2lzc3VlcnMvNTY1MDQ5IiwibmJmIjoxMjYyMzA0MDAwLCJqdGkiOiJodHRwOi8vZXhhbXBsZS5lZHUvY3JlZGVudGlhbHMvMzczMiIsInN1YiI6ImViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSIsImlhdCI6MTcxODM0OTI0MX0.ZtGycBKJUOav5eQYQYH10gjEcVYADNHhKDjntSa57jM2JoEj5ciW7tDEb6MJpFRUxrMk62AVi-OQ8dwW3HnZVw';
     nock('https://oidc4vci.demo.spruceid.com')
-    .post(/credential/)
-    .reply(200, {
-      format: 'jwt-vc',
-      credential: mockedVC,
-    });
+      .post(/credential/)
+      .reply(200, {
+        format: 'jwt-vc',
+        credential: mockedVC,
+      });
     const credReqClient = CredentialRequestClientBuilder.fromCredentialOfferRequest({ request: INITIATION_TEST })
-    .withCredentialEndpoint('https://oidc4vci.demo.spruceid.com/credential')
-    .withFormat('jwt_vc')
-    .withCredentialType('https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#OpenBadgeCredential')
-    .build();
+      .withCredentialEndpoint('https://oidc4vci.demo.spruceid.com/credential')
+      .withFormat('jwt_vc')
+      .withCredentialType('https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#OpenBadgeCredential')
+      .build();
     const proof: ProofOfPossession = await ProofOfPossessionBuilder.fromJwt({
       jwt: jwt1_0_13_withoutDid,
       callbacks: {
@@ -150,10 +149,10 @@ describe('Credential Request Client ', () => {
       },
       version: OpenId4VCIVersion.VER_1_0_13,
     })
-    // .withEndpointMetadata(metadata)
-    .withKid(kid_withoutDid)
-    .withClientId('sphereon:wallet')
-    .build();
+      // .withEndpointMetadata(metadata)
+      .withKid(kid_withoutDid)
+      .withClientId('sphereon:wallet')
+      .build();
     const credentialRequest = await credReqClient.createCredentialRequest({
       credentialType: 'OpenBadgeCredential',
       proofInput: proof,
@@ -190,10 +189,10 @@ describe('Credential Request Client ', () => {
 
   it('should fail with invalid url', async () => {
     const credReqClient = CredentialRequestClientBuilder.fromCredentialOfferRequest({ request: INITIATION_TEST })
-    .withCredentialEndpoint('httpsf://oidc4vci.demo.spruceid.com/credential')
-    .withFormat('jwt_vc')
-    .withCredentialType('https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#OpenBadgeCredential')
-    .build();
+      .withCredentialEndpoint('httpsf://oidc4vci.demo.spruceid.com/credential')
+      .withFormat('jwt_vc')
+      .withCredentialType('https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#OpenBadgeCredential')
+      .build();
     const proof: ProofOfPossession = await ProofOfPossessionBuilder.fromJwt({
       jwt: jwt1_0_08_withoutDid,
       callbacks: {
@@ -201,10 +200,10 @@ describe('Credential Request Client ', () => {
       },
       version: OpenId4VCIVersion.VER_1_0_08,
     })
-    // .withEndpointMetadata(metadata)
-    .withKid(kid_withoutDid)
-    .withClientId('sphereon:wallet')
-    .build();
+      // .withEndpointMetadata(metadata)
+      .withKid(kid_withoutDid)
+      .withClientId('sphereon:wallet')
+      .build();
     await expect(credReqClient.acquireCredentialsUsingRequest({ format: 'jwt_vc_json', types: ['random'], proof })).rejects.toThrow(
       Error(URL_NOT_VALID),
     );

--- a/packages/client/lib/__tests__/CredentialRequestClient.spec.ts
+++ b/packages/client/lib/__tests__/CredentialRequestClient.spec.ts
@@ -29,6 +29,8 @@ import { IDENTIPROOF_ISSUER_URL, IDENTIPROOF_OID4VCI_METADATA, INITIATION_TEST, 
 import { getMockData } from './data/VciDataFixtures';
 
 const partialJWT = 'eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmN';
+const partialJWT_withoutDid = 'eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJlYmZlYjFmNzEyZWJjNmYxYzI3N';
+
 
 const jwt1_0_08: Jwt = {
   header: { alg: Alg.ES256, kid: 'did:example:ebfeb1f712ebc6f1c276e12ec21/keys/1', typ: 'jwt' },
@@ -40,7 +42,19 @@ const jwt1_0_13: Jwt = {
   payload: { iss: 'sphereon:wallet', nonce: 'tZignsnFbp', jti: 'tZignsnFbp223', aud: IDENTIPROOF_ISSUER_URL },
 };
 
+const jwt1_0_08_withoutDid: Jwt = {
+  header: { alg: Alg.ES256, kid: 'ebfeb1f712ebc6f1c276e12ec21/keys/1', typ: 'jwt' },
+  payload: { iss: 'sphereon:wallet', nonce: 'tZignsnFbp', jti: 'tZignsnFbp223', aud: IDENTIPROOF_ISSUER_URL },
+};
+
+const jwt1_0_13_withoutDid: Jwt = {
+  header: { alg: Alg.ES256, kid: 'ebfeb1f712ebc6f1c276e12ec21/keys/1', typ: 'openid4vci-proof+jwt' },
+  payload: { iss: 'sphereon:wallet', nonce: 'tZignsnFbp', jti: 'tZignsnFbp223', aud: IDENTIPROOF_ISSUER_URL },
+};
+
 const kid = 'did:example:ebfeb1f712ebc6f1c276e12ec21/keys/1';
+
+const kid_withoutDid = 'ebfeb1f712ebc6f1c276e12ec21/keys/1';
 
 let keypair: KeyPair;
 
@@ -115,6 +129,43 @@ describe('Credential Request Client ', () => {
     expect(result?.successBody?.credential).toEqual(mockedVC);
   });
 
+  it('should get success credential response with kid without did', async function () {
+    const mockedVC =
+      'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sImlkIjoiaHR0cDovL2V4YW1wbGUuZWR1L2NyZWRlbnRpYWxzLzM3MzIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiVW5pdmVyc2l0eURlZ3JlZUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiaHR0cHM6Ly9leGFtcGxlLmVkdS9pc3N1ZXJzLzU2NTA0OSIsImlzc3VhbmNlRGF0ZSI6IjIwMTAtMDEtMDFUMDA6MDA6MDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJlYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMifX19LCJpc3MiOiJodHRwczovL2V4YW1wbGUuZWR1L2lzc3VlcnMvNTY1MDQ5IiwibmJmIjoxMjYyMzA0MDAwLCJqdGkiOiJodHRwOi8vZXhhbXBsZS5lZHUvY3JlZGVudGlhbHMvMzczMiIsInN1YiI6ImViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSIsImlhdCI6MTcxODM0OTI0MX0.ZtGycBKJUOav5eQYQYH10gjEcVYADNHhKDjntSa57jM2JoEj5ciW7tDEb6MJpFRUxrMk62AVi-OQ8dwW3HnZVw';
+    nock('https://oidc4vci.demo.spruceid.com')
+    .post(/credential/)
+    .reply(200, {
+      format: 'jwt-vc',
+      credential: mockedVC,
+    });
+    const credReqClient = CredentialRequestClientBuilder.fromCredentialOfferRequest({ request: INITIATION_TEST })
+    .withCredentialEndpoint('https://oidc4vci.demo.spruceid.com/credential')
+    .withFormat('jwt_vc')
+    .withCredentialType('https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#OpenBadgeCredential')
+    .build();
+    const proof: ProofOfPossession = await ProofOfPossessionBuilder.fromJwt({
+      jwt: jwt1_0_13_withoutDid,
+      callbacks: {
+        signCallback: proofOfPossessionCallbackFunction,
+      },
+      version: OpenId4VCIVersion.VER_1_0_13,
+    })
+    // .withEndpointMetadata(metadata)
+    .withKid(kid_withoutDid)
+    .withClientId('sphereon:wallet')
+    .build();
+    const credentialRequest = await credReqClient.createCredentialRequest({
+      credentialType: 'OpenBadgeCredential',
+      proofInput: proof,
+      format: 'jwt',
+      version: OpenId4VCIVersion.VER_1_0_13,
+    });
+    expect(credentialRequest.proof?.jwt?.includes(partialJWT_withoutDid)).toBeTruthy();
+    expect(credentialRequest.format).toEqual('jwt_vc');
+    const result = await credReqClient.acquireCredentialsUsingRequest(credentialRequest);
+    expect(result?.successBody?.credential).toEqual(mockedVC);
+  });
+
   it('should fail with invalid url', async () => {
     const credReqClient = CredentialRequestClientBuilder.fromCredentialOfferRequest({ request: INITIATION_TEST })
       .withCredentialEndpoint('httpsf://oidc4vci.demo.spruceid.com/credential')
@@ -132,6 +183,28 @@ describe('Credential Request Client ', () => {
       .withKid(kid)
       .withClientId('sphereon:wallet')
       .build();
+    await expect(credReqClient.acquireCredentialsUsingRequest({ format: 'jwt_vc_json', types: ['random'], proof })).rejects.toThrow(
+      Error(URL_NOT_VALID),
+    );
+  });
+
+  it('should fail with invalid url', async () => {
+    const credReqClient = CredentialRequestClientBuilder.fromCredentialOfferRequest({ request: INITIATION_TEST })
+    .withCredentialEndpoint('httpsf://oidc4vci.demo.spruceid.com/credential')
+    .withFormat('jwt_vc')
+    .withCredentialType('https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#OpenBadgeCredential')
+    .build();
+    const proof: ProofOfPossession = await ProofOfPossessionBuilder.fromJwt({
+      jwt: jwt1_0_08_withoutDid,
+      callbacks: {
+        signCallback: proofOfPossessionCallbackFunction,
+      },
+      version: OpenId4VCIVersion.VER_1_0_08,
+    })
+    // .withEndpointMetadata(metadata)
+    .withKid(kid_withoutDid)
+    .withClientId('sphereon:wallet')
+    .build();
     await expect(credReqClient.acquireCredentialsUsingRequest({ format: 'jwt_vc_json', types: ['random'], proof })).rejects.toThrow(
       Error(URL_NOT_VALID),
     );

--- a/packages/client/lib/__tests__/CredentialRequestClientBuilder.spec.ts
+++ b/packages/client/lib/__tests__/CredentialRequestClientBuilder.spec.ts
@@ -16,6 +16,7 @@ import { CredentialRequestClientBuilder, ProofOfPossessionBuilder } from '..';
 import { IDENTIPROOF_ISSUER_URL, IDENTIPROOF_OID4VCI_METADATA, INITIATION_TEST_URI, WALT_ISSUER_URL, WALT_OID4VCI_METADATA } from './MetadataMocks';
 
 const partialJWT = 'eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmN';
+const partialJWT_withoutDid = 'eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJlYmZlYjFmNzEyZWJjNmYxYzI3N';
 
 /*const jwtv1_0_08: Jwt = {
   header: { alg: Alg.ES256, kid: 'did:example:ebfeb1f712ebc6f1c276e12ec21/keys/1', typ: 'jwt' },
@@ -27,7 +28,13 @@ const jwtv1_0_11: Jwt = {
   payload: { iss: 'sphereon:wallet', nonce: 'tZignsnFbp', jti: 'tZignsnFbp223', aud: IDENTIPROOF_ISSUER_URL },
 };
 
+const jwtv1_0_11_withoutDid: Jwt = {
+  header: { alg: Alg.ES256, kid: 'ebfeb1f712ebc6f1c276e12ec21/keys/1', typ: 'openid4vci-proof+jwt' },
+  payload: { iss: 'sphereon:wallet', nonce: 'tZignsnFbp', jti: 'tZignsnFbp223', aud: IDENTIPROOF_ISSUER_URL },
+};
+
 const kid = 'did:example:ebfeb1f712ebc6f1c276e12ec21/keys/1';
+const kid_withoutDid = 'ebfeb1f712ebc6f1c276e12ec21/keys/1';
 
 let keypair: KeyPair;
 
@@ -109,6 +116,36 @@ describe('Credential Request Client Builder', () => {
       version: OpenId4VCIVersion.VER_1_0_13,
     });
     expect(credentialRequest.proof?.jwt).toContain(partialJWT);
+    expect('credential_identifier' in credentialRequest).toBe(true);
+    if ('types' in credentialRequest) {
+      expect(credentialRequest.types).toStrictEqual(['https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#OpenBadgeCredential']);
+    }
+  });
+
+  it('should build credential request correctly without did', async () => {
+    const credReqClient = (await CredentialRequestClientBuilder.fromURI({ uri: INITIATION_TEST_URI }))
+      .withCredentialEndpoint('https://oidc4vci.demo.spruceid.com/credential')
+      .withFormat('jwt_vc')
+      .withCredentialType('OpenBadgeCredential')
+      .build();
+    const proof: ProofOfPossession = await ProofOfPossessionBuilder.fromJwt({
+      jwt: jwtv1_0_11_withoutDid,
+      callbacks: {
+        signCallback: proofOfPossessionCallbackFunction,
+        verifyCallback: proofOfPossessionVerifierCallbackFunction,
+      },
+      version: OpenId4VCIVersion.VER_1_0_13,
+    })
+      .withClientId('sphereon:wallet')
+      .withKid(kid_withoutDid)
+      .build();
+    await proofOfPossessionVerifierCallbackFunction({ ...proof, kid: kid_withoutDid });
+    const credentialRequest: CredentialRequestV1_0_13 = await credReqClient.createCredentialRequest({
+      proofInput: proof,
+      credentialType: 'OpenBadgeCredential',
+      version: OpenId4VCIVersion.VER_1_0_13,
+    });
+    expect(credentialRequest.proof?.jwt).toContain(partialJWT_withoutDid);
     expect('credential_identifier' in credentialRequest).toBe(true);
     if ('types' in credentialRequest) {
       expect(credentialRequest.types).toStrictEqual(['https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#OpenBadgeCredential']);

--- a/packages/client/lib/__tests__/CredentialRequestClientV1_0_11.spec.ts
+++ b/packages/client/lib/__tests__/CredentialRequestClientV1_0_11.spec.ts
@@ -28,13 +28,21 @@ import {
 import { getMockData } from './data/VciDataFixtures';
 
 const partialJWT = 'eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmN';
+const partialJWT_withoutDid = 'eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJlYmZlYjFmNzEyZWJjNmYxYzI3N';
 
 const jwt: Jwt = {
   header: { alg: Alg.ES256, kid: 'did:example:ebfeb1f712ebc6f1c276e12ec21/keys/1', typ: 'jwt' },
   payload: { iss: 'sphereon:wallet', nonce: 'tZignsnFbp', jti: 'tZignsnFbp223', aud: IDENTIPROOF_ISSUER_URL },
 };
 
+const jwt_withoutDid: Jwt = {
+  header: { alg: Alg.ES256, kid: 'ebfeb1f712ebc6f1c276e12ec21/keys/1', typ: 'jwt' },
+  payload: { iss: 'sphereon:wallet', nonce: 'tZignsnFbp', jti: 'tZignsnFbp223', aud: IDENTIPROOF_ISSUER_URL },
+};
+
 const kid = 'did:example:ebfeb1f712ebc6f1c276e12ec21/keys/1';
+
+const kid_withoutDid = 'ebfeb1f712ebc6f1c276e12ec21/keys/1';
 
 let keypair: KeyPair;
 
@@ -102,6 +110,36 @@ describe('Credential Request Client ', () => {
     expect(result?.errorBody?.error).toBe('unsupported_format');
   });
 
+  it('should get a failed credential response with an unsupported format and without did', async function () {
+    const basePath = 'https://sphereonjunit2022101301.com/';
+    nock(basePath).post(/.*/).reply(500, {
+      error: 'unsupported_format',
+      error_description: 'This is a mock error message',
+    });
+
+    const credReqClient = CredentialRequestClientBuilderV1_0_11.fromCredentialOffer({ credentialOffer: INITIATION_TEST_V1_0_08 })
+      .withCredentialEndpoint(basePath + '/credential')
+      .withFormat('ldp_vc')
+      .withCredentialType('https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#OpenBadgeCredential')
+      .build();
+    const proof: ProofOfPossession = await ProofOfPossessionBuilder.fromJwt({
+      jwt: jwt_withoutDid,
+      callbacks: {
+        signCallback: proofOfPossessionCallbackFunction,
+      },
+      version: OpenId4VCIVersion.VER_1_0_08,
+    })
+      // .withEndpointMetadata(metadata)
+      .withClientId('sphereon:wallet')
+      .withKid(kid_withoutDid)
+      .build();
+    expect(credReqClient.getCredentialEndpoint()).toEqual(basePath + '/credential');
+    const credentialRequest = await credReqClient.createCredentialRequest({ proofInput: proof, version: OpenId4VCIVersion.VER_1_0_08 });
+    expect(credentialRequest.proof?.jwt?.includes(partialJWT_withoutDid)).toBeTruthy();
+    const result = await credReqClient.acquireCredentialsUsingRequest(credentialRequest);
+    expect(result?.errorBody?.error).toBe('unsupported_format');
+  });
+
   it('should get success credential response', async function () {
     const mockedVC =
       'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sImlkIjoiaHR0cDovL2V4YW1wbGUuZWR1L2NyZWRlbnRpYWxzLzM3MzIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiVW5pdmVyc2l0eURlZ3JlZUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiaHR0cHM6Ly9leGFtcGxlLmVkdS9pc3N1ZXJzLzU2NTA0OSIsImlzc3VhbmNlRGF0ZSI6IjIwMTAtMDEtMDFUMDA6MDA6MDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZXhhbXBsZTplYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMifX19LCJpc3MiOiJodHRwczovL2V4YW1wbGUuZWR1L2lzc3VlcnMvNTY1MDQ5IiwibmJmIjoxMjYyMzA0MDAwLCJqdGkiOiJodHRwOi8vZXhhbXBsZS5lZHUvY3JlZGVudGlhbHMvMzczMiIsInN1YiI6ImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJ9.z5vgMTK1nfizNCg5N-niCOL3WUIAL7nXy-nGhDZYO_-PNGeE-0djCpWAMH8fD8eWSID5PfkPBYkx_dfLJnQ7NA';
@@ -138,6 +176,42 @@ describe('Credential Request Client ', () => {
     expect(result?.successBody?.credential).toEqual(mockedVC);
   });
 
+  it('should get success credential response without did', async function () {
+    const mockedVC =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL2V4YW1wbGVzL3YxIl0sImlkIjoiaHR0cDovL2V4YW1wbGUuZWR1L2NyZWRlbnRpYWxzLzM3MzIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiVW5pdmVyc2l0eURlZ3JlZUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiaHR0cHM6Ly9leGFtcGxlLmVkdS9pc3N1ZXJzLzU2NTA0OSIsImlzc3VhbmNlRGF0ZSI6IjIwMTAtMDEtMDFUMDA6MDA6MDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJlYmZlYjFmNzEyZWJjNmYxYzI3NmUxMmVjMjEiLCJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMifX19LCJpc3MiOiJodHRwczovL2V4YW1wbGUuZWR1L2lzc3VlcnMvNTY1MDQ5IiwibmJmIjoxMjYyMzA0MDAwLCJqdGkiOiJodHRwOi8vZXhhbXBsZS5lZHUvY3JlZGVudGlhbHMvMzczMiIsInN1YiI6ImViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSIsImlhdCI6MTcxODM1NzcxOH0.7iiOTuIjQRyrIincYyDW6m0nBYmDoYfXcTYFrywsKEY';
+    nock('https://oidc4vci.demo.spruceid.com')
+      .post(/credential/)
+      .reply(200, {
+        format: 'jwt-vc',
+        credential: mockedVC,
+      });
+    const credReqClient = CredentialRequestClientBuilderV1_0_11.fromCredentialOfferRequest({ request: INITIATION_TEST })
+      .withCredentialEndpoint('https://oidc4vci.demo.spruceid.com/credential')
+      .withFormat('jwt_vc')
+      .withCredentialType('https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#OpenBadgeCredential')
+      .build();
+    const proof: ProofOfPossession = await ProofOfPossessionBuilder.fromJwt({
+      jwt: jwt_withoutDid,
+      callbacks: {
+        signCallback: proofOfPossessionCallbackFunction,
+      },
+      version: OpenId4VCIVersion.VER_1_0_08,
+    })
+      // .withEndpointMetadata(metadata)
+      .withKid(kid_withoutDid)
+      .withClientId('sphereon:wallet')
+      .build();
+    const credentialRequest = await credReqClient.createCredentialRequest({
+      proofInput: proof,
+      format: 'jwt',
+      version: OpenId4VCIVersion.VER_1_0_08,
+    });
+    expect(credentialRequest.proof?.jwt?.includes(partialJWT_withoutDid)).toBeTruthy();
+    expect(credentialRequest.format).toEqual('jwt_vc');
+    const result = await credReqClient.acquireCredentialsUsingRequest(credentialRequest);
+    expect(result?.successBody?.credential).toEqual(mockedVC);
+  });
+
   it('should fail with invalid url', async () => {
     const credReqClient = CredentialRequestClientBuilderV1_0_11.fromCredentialOfferRequest({ request: INITIATION_TEST })
       .withCredentialEndpoint('httpsf://oidc4vci.demo.spruceid.com/credential')
@@ -153,6 +227,28 @@ describe('Credential Request Client ', () => {
     })
       // .withEndpointMetadata(metadata)
       .withKid(kid)
+      .withClientId('sphereon:wallet')
+      .build();
+    await expect(credReqClient.acquireCredentialsUsingRequest({ format: 'jwt_vc_json', types: ['random'], proof })).rejects.toThrow(
+      Error(URL_NOT_VALID),
+    );
+  });
+
+  it('should fail with invalid url without did', async () => {
+    const credReqClient = CredentialRequestClientBuilderV1_0_11.fromCredentialOfferRequest({ request: INITIATION_TEST })
+      .withCredentialEndpoint('httpsf://oidc4vci.demo.spruceid.com/credential')
+      .withFormat('jwt_vc')
+      .withCredentialType('https://imsglobal.github.io/openbadges-specification/ob_v3p0.html#OpenBadgeCredential')
+      .build();
+    const proof: ProofOfPossession = await ProofOfPossessionBuilder.fromJwt({
+      jwt: jwt_withoutDid,
+      callbacks: {
+        signCallback: proofOfPossessionCallbackFunction,
+      },
+      version: OpenId4VCIVersion.VER_1_0_08,
+    })
+      // .withEndpointMetadata(metadata)
+      .withKid(kid_withoutDid)
       .withClientId('sphereon:wallet')
       .build();
     await expect(credReqClient.acquireCredentialsUsingRequest({ format: 'jwt_vc_json', types: ['random'], proof })).rejects.toThrow(

--- a/packages/client/lib/__tests__/IT.spec.ts
+++ b/packages/client/lib/__tests__/IT.spec.ts
@@ -240,8 +240,8 @@ describe('OID4VCI-Client should', () => {
       });
 
       nock(ISSUER_URL)
-      .post(/token.*/)
-      .reply(200, JSON.stringify(mockedAccessTokenResponse));
+        .post(/token.*/)
+        .reply(200, JSON.stringify(mockedAccessTokenResponse));
 
       /* The actual access token calls */
       const accessTokenClient: AccessTokenClientV1_0_11 = new AccessTokenClientV1_0_11();
@@ -249,16 +249,16 @@ describe('OID4VCI-Client should', () => {
       expect(accessTokenResponse.successBody).toEqual(mockedAccessTokenResponse);
       // Get the credential
       nock(ISSUER_URL)
-      .post(/credential/)
-      .reply(200, {
-        format: 'jwt-vc',
-        credential: mockedVC,
-      });
+        .post(/credential/)
+        .reply(200, {
+          format: 'jwt-vc',
+          credential: mockedVC,
+        });
       const credReqClient = CredentialRequestClientBuilderV1_0_11.fromCredentialOffer({ credentialOffer: credentialOffer })
-      .withFormat('jwt_vc')
+        .withFormat('jwt_vc')
 
-      .withTokenFromResponse(accessTokenResponse.successBody!)
-      .build();
+        .withTokenFromResponse(accessTokenResponse.successBody!)
+        .build();
 
       //TS2322: Type '(args: ProofOfPossessionCallbackArgs) => Promise<string>'
       // is not assignable to type 'ProofOfPossessionCallback'.
@@ -271,13 +271,13 @@ describe('OID4VCI-Client should', () => {
         },
         version: OpenId4VCIVersion.VER_1_0_11,
       })
-      .withEndpointMetadata({
-        issuer: 'https://issuer.research.identiproof.io',
-        credential_endpoint: 'https://issuer.research.identiproof.io/credential',
-        token_endpoint: 'https://issuer.research.identiproof.io/token',
-      })
-      .withKid('ebfeb1f712ebc6f1c276e12ec21/keys/1')
-      .build();
+        .withEndpointMetadata({
+          issuer: 'https://issuer.research.identiproof.io',
+          credential_endpoint: 'https://issuer.research.identiproof.io/credential',
+          token_endpoint: 'https://issuer.research.identiproof.io/token',
+        })
+        .withKid('ebfeb1f712ebc6f1c276e12ec21/keys/1')
+        .build();
       const credResponse = await credReqClient.acquireCredentialsUsingProof({ proofInput: proof });
       expect(credResponse.successBody?.credential).toEqual(mockedVC);
     },
@@ -371,8 +371,8 @@ describe('OID4VCI-Client should', () => {
       });
 
       nock(ISSUER_URL)
-      .post(/token.*/)
-      .reply(200, JSON.stringify(mockedAccessTokenResponse));
+        .post(/token.*/)
+        .reply(200, JSON.stringify(mockedAccessTokenResponse));
 
       /* The actual access token calls */
       const accessTokenClient: AccessTokenClient = new AccessTokenClient();
@@ -380,16 +380,16 @@ describe('OID4VCI-Client should', () => {
       expect(accessTokenResponse.successBody).toEqual(mockedAccessTokenResponse);
       // Get the credential
       nock(ISSUER_URL)
-      .post(/credential/)
-      .reply(200, {
-        format: 'jwt-vc',
-        credential: mockedVC,
-      });
+        .post(/credential/)
+        .reply(200, {
+          format: 'jwt-vc',
+          credential: mockedVC,
+        });
       const credReqClient = CredentialRequestClientBuilder.fromCredentialOffer({ credentialOffer: credentialOffer })
-      .withFormat('jwt_vc')
+        .withFormat('jwt_vc')
 
-      .withTokenFromResponse(accessTokenResponse.successBody!)
-      .build();
+        .withTokenFromResponse(accessTokenResponse.successBody!)
+        .build();
 
       //TS2322: Type '(args: ProofOfPossessionCallbackArgs) => Promise<string>'
       // is not assignable to type 'ProofOfPossessionCallback'.
@@ -402,13 +402,13 @@ describe('OID4VCI-Client should', () => {
         },
         version: OpenId4VCIVersion.VER_1_0_11,
       })
-      .withEndpointMetadata({
-        issuer: 'https://issuer.research.identiproof.io',
-        credential_endpoint: 'https://issuer.research.identiproof.io/credential',
-        token_endpoint: 'https://issuer.research.identiproof.io/token',
-      })
-      .withKid('ebfeb1f712ebc6f1c276e12ec21/keys/1')
-      .build();
+        .withEndpointMetadata({
+          issuer: 'https://issuer.research.identiproof.io',
+          credential_endpoint: 'https://issuer.research.identiproof.io/credential',
+          token_endpoint: 'https://issuer.research.identiproof.io/token',
+        })
+        .withKid('ebfeb1f712ebc6f1c276e12ec21/keys/1')
+        .build();
       const credResponse = await credReqClient.acquireCredentialsUsingProof({
         proofInput: proof,
         credentialType: credentialOffer.original_credential_offer.credential_configuration_ids[0],

--- a/packages/client/lib/__tests__/SdJwt.spec.ts
+++ b/packages/client/lib/__tests__/SdJwt.spec.ts
@@ -164,4 +164,105 @@ describe('sd-jwt vc', () => {
     },
     UNIT_TEST_TIMEOUT,
   );
+
+  it(
+    'succeed with a full flow without did',
+    async () => {
+      const offerUri = await vcIssuer.createCredentialOfferURI({
+        grants: {
+          'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
+            tx_code: {
+              input_mode: 'text',
+              length: 3,
+            },
+            'pre-authorized_code': '123',
+          },
+        },
+        credential_configuration_ids: ['SdJwtCredential'],
+      });
+
+      nock(vcIssuer.issuerMetadata.credential_issuer).get('/.well-known/openid-credential-issuer').reply(200, JSON.stringify(issuerMetadata));
+      nock(vcIssuer.issuerMetadata.credential_issuer).get('/.well-known/openid-configuration').reply(404);
+      nock(vcIssuer.issuerMetadata.credential_issuer).get('/.well-known/oauth-authorization-server').reply(404);
+
+      expect(offerUri.uri).toEqual(
+        'openid-credential-offer://?credential_offer=%7B%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%22123%22%2C%22tx_code%22%3A%7B%22input_mode%22%3A%22text%22%2C%22length%22%3A3%7D%7D%7D%2C%22credential_configuration_ids%22%3A%5B%22SdJwtCredential%22%5D%2C%22credential_issuer%22%3A%22https%3A%2F%2Fexample.com%22%7D',
+      );
+
+      const client = await OpenID4VCIClient.fromURI({
+        uri: offerUri.uri,
+      });
+
+      expect(client.credentialOffer?.credential_offer).toEqual({
+        credential_issuer: 'https://example.com',
+        credential_configuration_ids: ['SdJwtCredential'],
+        grants: {
+          'urn:ietf:params:oauth:grant-type:pre-authorized_code': {
+            'pre-authorized_code': '123',
+            tx_code: {
+              input_mode: 'text',
+              length: 3,
+            },
+          },
+        },
+      });
+
+      const supported = client.getCredentialsSupported('vc+sd-jwt');
+      expect(supported).toEqual({ SdJwtCredentialId: { format: 'vc+sd-jwt', id: 'SdJwtCredentialId', vct: 'SdJwtCredential' } });
+
+      const offered = supported['SdJwtCredentialId'] as CredentialSupportedSdJwtVc;
+
+      nock(issuerMetadata.token_endpoint as string)
+        .post('/')
+        .reply(200, async (_, body: string) => {
+          const parsedBody = Object.fromEntries(body.split('&').map((x) => x.split('=')));
+          return createAccessTokenResponse(parsedBody as AccessTokenRequest, {
+            credentialOfferSessions: vcIssuer.credentialOfferSessions,
+            accessTokenIssuer: 'https://issuer.example.com',
+            cNonces: vcIssuer.cNonces,
+            cNonce: 'a-c-nonce',
+            accessTokenSignerCallback: async () => 'ey.val.ue',
+            tokenExpiresIn: 500,
+          });
+        });
+
+      await client.acquireAccessToken({ pin: '123' });
+      nock(issuerMetadata.credential_endpoint as string)
+        .post('/')
+        .reply(200, async (_, body) =>
+          vcIssuer.issueCredential({
+            credentialRequest: { ...(body as CredentialRequestV1_0_13), credential_identifier: offered.vct },
+            credential: {
+              vct: 'Hello',
+              iss: 'example.com',
+              iat: 123,
+              // Defines what can be disclosed (optional)
+              __disclosureFrame: {
+                name: true,
+              },
+            },
+            newCNonce: 'new-c-nonce',
+          }),
+        );
+
+      const credentials = await client.acquireCredentials({
+        credentialType: offered.vct,
+        format: 'vc+sd-jwt',
+        alg,
+        jwk,
+        proofCallbacks: {
+          // When using sd-jwt for real, this jwt should include a jwk
+          signCallback: async () => 'ey.ja.ja',
+        },
+      });
+
+      expect(credentials).toEqual({
+        c_nonce: 'new-c-nonce',
+        c_nonce_expires_in: 300,
+        credential: 'sd-jwt',
+        format: 'vc+sd-jwt',
+      });
+    },
+    UNIT_TEST_TIMEOUT,
+  );
 });

--- a/packages/client/lib/functions/ProofUtil.ts
+++ b/packages/client/lib/functions/ProofUtil.ts
@@ -107,7 +107,7 @@ const createJWT = (jwtProps?: JwtProps, existingJwt?: Jwt): Jwt => {
     typ,
     alg,
     ...(kid && { kid }),
-    ...(jwk && { jwk } ),
+    ...(jwk && { jwk }),
     ...(x5c && { x5c }),
   };
   return {
@@ -116,7 +116,13 @@ const createJWT = (jwtProps?: JwtProps, existingJwt?: Jwt): Jwt => {
   };
 };
 
-const getJwtProperty = <T>(propertyName: string, required: boolean, option?: string | string[] | JWK, jwtProperty?: T, defaultValue?: T): T | undefined => {
+const getJwtProperty = <T>(
+  propertyName: string,
+  required: boolean,
+  option?: string | string[] | JWK,
+  jwtProperty?: T,
+  defaultValue?: T,
+): T | undefined => {
   if ((typeof option === 'string' || Array.isArray(option)) && option && jwtProperty && option !== jwtProperty) {
     throw Error(`Cannot have a property '${propertyName}' with value '${option}' and different JWT value '${jwtProperty}' at the same time`);
   }

--- a/packages/issuer/lib/VcIssuer.ts
+++ b/packages/issuer/lib/VcIssuer.ts
@@ -21,8 +21,7 @@ import {
   JsonLdIssuerCredentialDefinition,
   JWT_VERIFY_CONFIG_ERROR,
   JWTVerifyCallback,
-  JwtVerifyResult,
-  KID_DID_NO_DID_ERROR,
+  JwtVerifyResult, KID_DID_NO_DID_ERROR,
   KID_JWK_X5C_ERROR,
   NO_ISS_IN_AUTHORIZATION_CODE_CONTEXT,
   OID4VCICredentialFormat,
@@ -33,7 +32,7 @@ import {
   TxCode,
   TYP_ERROR,
   UniformCredentialRequest,
-  URIState,
+  URIState
 } from '@sphereon/oid4vci-common'
 import { CredentialIssuerMetadataOptsV1_0_13 } from '@sphereon/oid4vci-common/dist/types/v1_0_13.types'
 import { CompactSdJwtVc, CredentialMapper, W3CVerifiableCredential } from '@sphereon/ssi-types'
@@ -467,8 +466,13 @@ export class VcIssuer<DIDDoc extends object> {
         // only 1 is allowed, but need to look into whether jwk and x5c are allowed together
         throw Error(KID_JWK_X5C_ERROR)
       } else if (kid && !did) {
-        // Make sure the callback function extracts the DID from the kid
-        throw Error(KID_DID_NO_DID_ERROR)
+        if (!jwk && !x5c) {
+          // Make sure the callback function extracts the DID from the kid
+          throw Error(KID_DID_NO_DID_ERROR);
+        } else {
+          // If JWK or x5c is present, log the information and proceed
+          console.log(`KID present but no DID, using JWK or x5c`);
+        }
       } else if (did && !didDocument) {
         // Make sure the callback function does DID resolution when a did is present
         throw Error(DID_NO_DIDDOC_ERROR)

--- a/packages/issuer/lib/VcIssuer.ts
+++ b/packages/issuer/lib/VcIssuer.ts
@@ -21,7 +21,8 @@ import {
   JsonLdIssuerCredentialDefinition,
   JWT_VERIFY_CONFIG_ERROR,
   JWTVerifyCallback,
-  JwtVerifyResult, KID_DID_NO_DID_ERROR,
+  JwtVerifyResult,
+  KID_DID_NO_DID_ERROR,
   KID_JWK_X5C_ERROR,
   NO_ISS_IN_AUTHORIZATION_CODE_CONTEXT,
   OID4VCICredentialFormat,
@@ -32,7 +33,7 @@ import {
   TxCode,
   TYP_ERROR,
   UniformCredentialRequest,
-  URIState
+  URIState,
 } from '@sphereon/oid4vci-common'
 import { CredentialIssuerMetadataOptsV1_0_13 } from '@sphereon/oid4vci-common/dist/types/v1_0_13.types'
 import { CompactSdJwtVc, CredentialMapper, W3CVerifiableCredential } from '@sphereon/ssi-types'
@@ -468,10 +469,10 @@ export class VcIssuer<DIDDoc extends object> {
       } else if (kid && !did) {
         if (!jwk && !x5c) {
           // Make sure the callback function extracts the DID from the kid
-          throw Error(KID_DID_NO_DID_ERROR);
+          throw Error(KID_DID_NO_DID_ERROR)
         } else {
           // If JWK or x5c is present, log the information and proceed
-          console.log(`KID present but no DID, using JWK or x5c`);
+          console.log(`KID present but no DID, using JWK or x5c`)
         }
       } else if (did && !didDocument) {
         // Make sure the callback function does DID resolution when a did is present

--- a/packages/issuer/lib/__tests__/VcIssuerBuilder.spec.ts
+++ b/packages/issuer/lib/__tests__/VcIssuerBuilder.spec.ts
@@ -149,4 +149,62 @@ describe('VcIssuer builder should', () => {
       credentialOffer: { credential_offer: { credentials: ['test_credential'], credential_issuer: 'test_issuer' } },
     })
   })
+
+  it('should successfully attach an instance of the ICredentialOfferStateManager to the VcIssuer instance without did', async () => {
+    const credentialsSupported: Record<string, CredentialConfigurationSupportedV1_0_13> = new CredentialSupportedBuilderV1_13()
+      .withCredentialSigningAlgValuesSupported('ES256K')
+      .withCryptographicBindingMethod('jwk')
+      .withFormat('jwt_vc_json')
+      .withCredentialName('UniversityDegree_JWT')
+      .withCredentialDefinition({
+        type: ['VerifiableCredential', 'UniversityDegree_JWT'],
+      })
+      .withCredentialSupportedDisplay({
+        name: 'University Credential',
+        locale: 'en-US',
+        logo: {
+          url: 'https://exampleuniversity.com/public/logo.png',
+          alt_text: 'a square logo of a university',
+        },
+        background_color: '#12107c',
+        text_color: '#FFFFFF',
+      })
+      .addCredentialSubjectPropertyDisplay('given_name', {
+        name: 'given name',
+        locale: 'en-US',
+      } as IssuerCredentialSubjectDisplay)
+      .build()
+    const vcIssuer = new VcIssuerBuilder()
+      .withAuthorizationServers('https://authorization-server')
+      .withCredentialEndpoint('https://credential-endpoint')
+      .withCredentialIssuer('https://credential-issuer')
+      .withIssuerDisplay({
+        name: 'example issuer',
+        locale: 'en-US',
+      })
+      .withCredentialConfigurationsSupported(credentialsSupported)
+      .withInMemoryCredentialOfferState()
+      .withInMemoryCNonceState()
+      .build()
+    console.log(JSON.stringify(vcIssuer.issuerMetadata))
+    expect(vcIssuer).toBeDefined()
+    const preAuthorizedCodecreatedAt = +new Date()
+    await vcIssuer.credentialOfferSessions?.set('test', {
+      issuerState: v4(),
+      lastUpdatedAt: preAuthorizedCodecreatedAt,
+      status: IssueStatus.OFFER_CREATED,
+      clientId: 'test_client',
+      createdAt: preAuthorizedCodecreatedAt,
+      userPin: '123456',
+      credentialOffer: { credential_offer: { credentials: ['test_credential'], credential_issuer: 'test_issuer' } },
+    })
+    await expect(vcIssuer.credentialOfferSessions?.get('test')).resolves.toMatchObject({
+      clientId: 'test_client',
+      userPin: '123456',
+      status: IssueStatus.OFFER_CREATED,
+      lastUpdatedAt: preAuthorizedCodecreatedAt,
+      createdAt: preAuthorizedCodecreatedAt,
+      credentialOffer: { credential_offer: { credentials: ['test_credential'], credential_issuer: 'test_issuer' } },
+    })
+  })
 })


### PR DESCRIPTION
Ensure VCI client and server can work with plain JWKs not using DIDs
-  added support for `x5c`
- modified default value of `typ` to be `openid4vci-proof+jwt`